### PR TITLE
Refactor tests to use `enzyme`

### DIFF
--- a/.vtexignore
+++ b/.vtexignore
@@ -7,3 +7,6 @@ src/
 package.json
 README.md
 CHANGELOG.md
+react/__tests__/**
+react/.babelrc
+react/setupTests.js

--- a/react/CategoryMenu.js
+++ b/react/CategoryMenu.js
@@ -29,6 +29,10 @@ class CategoryMenu extends Component {
 }
 
 CategoryMenu.propTypes = {
+  /** Whether to show the promotion category or not */
+  showPromotionCategory: PropTypes.bool.isRequired,
+  /** Whether to show the gift category or not */
+  showGiftCategory: PropTypes.bool.isRequired,
   data: PropTypes.shape({
     loading: PropTypes.bool.isRequired,
     categories: PropTypes.arrayOf(
@@ -38,6 +42,22 @@ CategoryMenu.propTypes = {
       })
     ),
   }),
+}
+
+CategoryMenu.schema = {
+  title: 'Category Menu',
+  description: 'A menu showing a list of the available categories on the store',
+  type: 'object',
+  properties: {
+    showPromotionCategory: {
+      type: 'boolean',
+      title: 'Show the promotion category',
+    },
+    showGiftCategory: {
+      type: 'boolean',
+      title: 'Show the gifts category',
+    },
+  },
 }
 
 export default graphql(getCategories)(CategoryMenu)

--- a/react/CategoryMenu.js
+++ b/react/CategoryMenu.js
@@ -9,7 +9,7 @@ import LoadingBar from './components/LoadingBar'
 /**
  * Component that represents the menu containing the categories of the store
  */
-class CategoryMenu extends Component {
+export class CategoryMenu extends Component {
   render() {
     const { data: { categories, loading } } = this.props
 
@@ -30,9 +30,9 @@ class CategoryMenu extends Component {
 
 CategoryMenu.propTypes = {
   /** Whether to show the promotion category or not */
-  showPromotionCategory: PropTypes.bool.isRequired,
+  showPromotionCategory: PropTypes.bool,
   /** Whether to show the gift category or not */
-  showGiftCategory: PropTypes.bool.isRequired,
+  showGiftCategory: PropTypes.bool,
   data: PropTypes.shape({
     loading: PropTypes.bool.isRequired,
     categories: PropTypes.arrayOf(
@@ -42,6 +42,11 @@ CategoryMenu.propTypes = {
       })
     ),
   }),
+}
+
+CategoryMenu.defaultProps = {
+  showPromotionCategory: false,
+  showGiftCategory: false,
 }
 
 CategoryMenu.schema = {

--- a/react/__tests__/CategoryItem.test.js
+++ b/react/__tests__/CategoryItem.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { shallow } from 'enzyme'
 
 import CategoryItem from '../components/CategoryItem'
 
@@ -23,13 +23,11 @@ describe('CategoryItem component', () => {
       ],
     }
 
-    wrapper = mount(<CategoryItem category={categoryMock} />)
+    wrapper = shallow(<CategoryItem category={categoryMock} />)
   })
 
   it('should have the correct href', () => {
-    expect(wrapper.getDOMNode().querySelector('a').href).toBe(
-      `${location.href}#1`
-    )
+    expect(wrapper.find({ href: '#1' }).exists()).toBe(true)
   })
 
   it('should match snapshot', () => {

--- a/react/__tests__/CategoryItem.test.js
+++ b/react/__tests__/CategoryItem.test.js
@@ -1,6 +1,5 @@
-/* eslint-env jest */
 import React from 'react'
-import { render } from 'react-testing-library'
+import { mount } from 'enzyme'
 
 import CategoryItem from '../components/CategoryItem'
 
@@ -24,14 +23,16 @@ describe('CategoryItem component', () => {
       ],
     }
 
-    wrapper = render(<CategoryItem category={categoryMock} />)
+    wrapper = mount(<CategoryItem category={categoryMock} />)
   })
 
   it('should have the correct href', () => {
-    expect(wrapper.getByText('Category').href).toBe(`${location.href}#1`)
+    expect(wrapper.getDOMNode().querySelector('a').href).toBe(
+      `${location.href}#1`
+    )
   })
 
   it('should match snapshot', () => {
-    expect(wrapper.container).toMatchSnapshot()
+    expect(wrapper.getElement()).toMatchSnapshot()
   })
 })

--- a/react/__tests__/CategoryItem.test.js
+++ b/react/__tests__/CategoryItem.test.js
@@ -31,6 +31,6 @@ describe('CategoryItem component', () => {
   })
 
   it('should match snapshot', () => {
-    expect(wrapper.getElement()).toMatchSnapshot()
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/react/__tests__/CategoryMenu.test.js
+++ b/react/__tests__/CategoryMenu.test.js
@@ -49,7 +49,7 @@ describe('CategoryMenu component', () => {
   })
 
   it('should match snapshot', () => {
-    expect(wrapper.getElement()).toMatchSnapshot()
+    expect(wrapper).toMatchSnapshot()
   })
 
   it('should render 3 menu items', () => {

--- a/react/__tests__/CategoryMenu.test.js
+++ b/react/__tests__/CategoryMenu.test.js
@@ -1,15 +1,12 @@
-/* eslint-env jest */
 import React from 'react'
-import { render } from 'react-testing-library'
-import { MockedProvider } from 'react-apollo/test-utils'
+import { mount } from 'enzyme'
 
-import CategoryMenu from '../CategoryMenu'
-import getCategories from '../queries/categoriesQuery.gql'
+import { CategoryMenu } from '../CategoryMenu'
 
 describe('CategoryMenu component', () => {
   let wrapper
 
-  beforeEach(done => {
+  beforeEach(() => {
     const mockedCategories = [
       {
         id: 1,
@@ -37,24 +34,14 @@ describe('CategoryMenu component', () => {
       },
     ]
 
-    wrapper = render(
-      <MockedProvider
-        mocks={[
-          {
-            request: { query: getCategories },
-            result: { data: { categories: mockedCategories } },
-          },
-        ]}
-      >
-        <CategoryMenu />
-      </MockedProvider>
+    wrapper = mount(
+      <CategoryMenu
+        data={{
+          categories: mockedCategories,
+          loading: false,
+        }}
+      />
     )
-
-    // necessary because we need to wait for the graphql
-    // response, even if it's a mocked one
-    setTimeout(() => {
-      done()
-    }, 0)
   })
 
   it('should be rendered', () => {
@@ -62,16 +49,26 @@ describe('CategoryMenu component', () => {
   })
 
   it('should match snapshot', () => {
-    expect(wrapper.container).toMatchSnapshot()
+    expect(wrapper.getElement()).toMatchSnapshot()
   })
 
   it('should render 3 menu items', () => {
+    expect(wrapper.find('[data-testid="category-item"]').length).toBe(3)
+  })
+
+  it('should have all provided categories', () => {
     expect(
-      wrapper.container.querySelectorAll('[data-testid="category-item"]').length
-    ).toBe(3)
+      wrapper.containsAllMatchingElements([
+        /* eslint-disable react/jsx-key */
+        <a>Category 1</a>,
+        <a>Category 2</a>,
+        <a>Category 3</a>,
+        /* eslint-enable */
+      ])
+    ).toBe(true)
   })
 
   it("shouldn't be able to find a `Category 4` item", () => {
-    expect(() => wrapper.getByText('Category 4')).toThrow()
+    expect(wrapper.containsMatchingElement(<a>Category 4</a>)).toBe(false)
   })
 })

--- a/react/__tests__/__snapshots__/CategoryItem.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryItem.test.js.snap
@@ -1,40 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CategoryItem component should match snapshot 1`] = `
-<div>
-  <div
-    class="h3 w4"
-    data-testid="category-item"
-  >
-    <div
-      class="h-100 w-100 dib pl5 pr4 vtex-category-item black-90 hover-bg-black-90 hover-white show-arrow"
-    >
-      <a
-        class="db mt6 no-underline ttu"
-        href="#1"
-      >
-        Category
-      </a>
-      <div
-        class="vtex-category-sub-menu pv6 ph5 br2 br--bottom"
-        data-testid="category-submenu"
-      >
-        <ul
-          class="list ma0 pa0 f6"
-        >
-          <li
-            class="lh-copy"
-          >
-            <a
-              class="near-black no-underline underline-hover"
-              href="#2"
-            >
-              Sub-category
-            </a>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </div>
-</div>
+<CategoryItem
+  category={
+    Object {
+      "children": Array [
+        Object {
+          "href": "#2",
+          "id": 2,
+          "name": "Sub-category",
+          "slug": "sub-category",
+        },
+      ],
+      "hasChildren": true,
+      "href": "#1",
+      "id": 1,
+      "name": "Category",
+      "slug": "category",
+    }
+  }
+/>
 `;

--- a/react/__tests__/__snapshots__/CategoryItem.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryItem.test.js.snap
@@ -28,6 +28,7 @@ exports[`CategoryItem component should match snapshot 1`] = `
       >
         <li
           className="lh-copy"
+          key="2"
         >
           <a
             className="near-black no-underline underline-hover"

--- a/react/__tests__/__snapshots__/CategoryItem.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryItem.test.js.snap
@@ -1,23 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CategoryItem component should match snapshot 1`] = `
-<CategoryItem
-  category={
-    Object {
-      "children": Array [
+<div
+  className="h3 w4"
+  data-testid="category-item"
+>
+  <div
+    className="h-100 w-100 dib pl5 pr4 vtex-category-item black-90 hover-bg-black-90 hover-white show-arrow"
+  >
+    <a
+      className="db mt6 no-underline ttu"
+      href="#1"
+      style={
         Object {
-          "href": "#2",
-          "id": 2,
-          "name": "Sub-category",
-          "slug": "sub-category",
-        },
-      ],
-      "hasChildren": true,
-      "href": "#1",
-      "id": 1,
-      "name": "Category",
-      "slug": "category",
-    }
-  }
-/>
+          "color": "inherit",
+        }
+      }
+    >
+      Category
+    </a>
+    <div
+      className="vtex-category-sub-menu pv6 ph5 br2 br--bottom"
+      data-testid="category-submenu"
+    >
+      <ul
+        className="list ma0 pa0 f6"
+      >
+        <li
+          className="lh-copy"
+        >
+          <a
+            className="near-black no-underline underline-hover"
+            href="#2"
+          >
+            Sub-category
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
 `;

--- a/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
@@ -1,59 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CategoryMenu component should match snapshot 1`] = `
-<div>
-  <div
-    class="h3 bg-near-white"
-  >
-    <nav
-      class="flex w-two-thirds center h0"
-    >
-      <div
-        class="h3 w4"
-        data-testid="category-item"
-      >
-        <div
-          class="h-100 w-100 dib pl5 pr4 vtex-category-item black-90 hover-bg-black-90 hover-white"
-        >
-          <a
-            class="db mt6 no-underline ttu"
-            href="#1"
-          >
-            Category 1
-          </a>
-        </div>
-      </div>
-      <div
-        class="h3 w4"
-        data-testid="category-item"
-      >
-        <div
-          class="h-100 w-100 dib pl5 pr4 vtex-category-item black-90 hover-bg-black-90 hover-white"
-        >
-          <a
-            class="db mt6 no-underline ttu"
-            href="#2"
-          >
-            Category 2
-          </a>
-        </div>
-      </div>
-      <div
-        class="h3 w4"
-        data-testid="category-item"
-      >
-        <div
-          class="h-100 w-100 dib pl5 pr4 vtex-category-item black-90 hover-bg-black-90 hover-white"
-        >
-          <a
-            class="db mt6 no-underline ttu"
-            href="#3"
-          >
-            Category 3
-          </a>
-        </div>
-      </div>
-    </nav>
-  </div>
-</div>
+<CategoryMenu
+  data={
+    Object {
+      "categories": Array [
+        Object {
+          "children": Array [],
+          "hasChildren": false,
+          "href": "#1",
+          "id": 1,
+          "name": "Category 1",
+          "slug": "category-1",
+        },
+        Object {
+          "children": Array [],
+          "hasChildren": false,
+          "href": "#2",
+          "id": 2,
+          "name": "Category 2",
+          "slug": "category-2",
+        },
+        Object {
+          "children": Array [],
+          "hasChildren": false,
+          "href": "#3",
+          "id": 3,
+          "name": "Category 3",
+          "slug": "category-3",
+        },
+      ],
+      "loading": false,
+    }
+  }
+  showGiftCategory={false}
+  showPromotionCategory={false}
+/>
 `;

--- a/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
@@ -35,5 +35,121 @@ exports[`CategoryMenu component should match snapshot 1`] = `
   }
   showGiftCategory={false}
   showPromotionCategory={false}
-/>
+>
+  <LoadingBar
+    fallback={null}
+    loading={false}
+  >
+    <div
+      className="h3 bg-near-white"
+    >
+      <nav
+        className="flex w-two-thirds center h0"
+      >
+        <CategoryItem
+          category={
+            Object {
+              "children": Array [],
+              "hasChildren": false,
+              "href": "#1",
+              "id": 1,
+              "name": "Category 1",
+              "slug": "category-1",
+            }
+          }
+          key="1"
+        >
+          <div
+            className="h3 w4"
+            data-testid="category-item"
+          >
+            <div
+              className="h-100 w-100 dib pl5 pr4 vtex-category-item black-90 hover-bg-black-90 hover-white"
+            >
+              <a
+                className="db mt6 no-underline ttu"
+                href="#1"
+                style={
+                  Object {
+                    "color": "inherit",
+                  }
+                }
+              >
+                Category 1
+              </a>
+            </div>
+          </div>
+        </CategoryItem>
+        <CategoryItem
+          category={
+            Object {
+              "children": Array [],
+              "hasChildren": false,
+              "href": "#2",
+              "id": 2,
+              "name": "Category 2",
+              "slug": "category-2",
+            }
+          }
+          key="2"
+        >
+          <div
+            className="h3 w4"
+            data-testid="category-item"
+          >
+            <div
+              className="h-100 w-100 dib pl5 pr4 vtex-category-item black-90 hover-bg-black-90 hover-white"
+            >
+              <a
+                className="db mt6 no-underline ttu"
+                href="#2"
+                style={
+                  Object {
+                    "color": "inherit",
+                  }
+                }
+              >
+                Category 2
+              </a>
+            </div>
+          </div>
+        </CategoryItem>
+        <CategoryItem
+          category={
+            Object {
+              "children": Array [],
+              "hasChildren": false,
+              "href": "#3",
+              "id": 3,
+              "name": "Category 3",
+              "slug": "category-3",
+            }
+          }
+          key="3"
+        >
+          <div
+            className="h3 w4"
+            data-testid="category-item"
+          >
+            <div
+              className="h-100 w-100 dib pl5 pr4 vtex-category-item black-90 hover-bg-black-90 hover-white"
+            >
+              <a
+                className="db mt6 no-underline ttu"
+                href="#3"
+                style={
+                  Object {
+                    "color": "inherit",
+                  }
+                }
+              >
+                Category 3
+              </a>
+            </div>
+          </div>
+        </CategoryItem>
+      </nav>
+    </div>
+  </LoadingBar>
+</CategoryMenu>
 `;

--- a/react/package.json
+++ b/react/package.json
@@ -14,21 +14,25 @@
     "babel-jest": "^22.4.3",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react-app": "^3.1.1",
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "^1.1.1",
+    "enzyme-to-json": "^3.3.3",
     "graphql": "^0.13.2",
     "graphql-tag": "^2.8.0",
     "jest": "^22.4.3",
     "jest-transform-graphql": "^2.1.0",
     "react": "^16.3.1",
     "react-apollo": "^2.1.3",
-    "react-dom": "^16.3.1",
-    "react-testing-library": "^2.1.1"
+    "react-dom": "^16.3.1"
   },
   "jest": {
     "verbose": true,
+    "setupTestFrameworkScriptFile": "<rootDir>/setupTests.js",
     "transform": {
       "\\.(gql|graphql)$": "jest-transform-graphql",
       "^.+\\.(js|jsx|mjs)$": "<rootDir>/node_modules/babel-jest"
     },
-    "transformIgnorePatterns": ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$"]
+    "transformIgnorePatterns": ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$"],
+    "snapshotSerializers": ["enzyme-to-json/serializer"]
   }
 }

--- a/react/setupTests.js
+++ b/react/setupTests.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+
+Enzyme.configure({ adapter: new Adapter() })

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -20,6 +20,10 @@
   version "2.0.47"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.47.tgz#f49ba1dd1f189486beb6e1d070a850f6ab4bd521"
 
+"@types/node@*":
+  version "9.6.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.5.tgz#ee700810fdf49ac1c399fc5980b7559b3e5a381d"
+
 "@types/node@^9.4.6":
   version "9.6.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.4.tgz#0ef7b4cfc3499881c81e0ea1ce61a23f6f4f5b42"
@@ -945,6 +949,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -1087,6 +1095,17 @@ chalk@^2.0.0, chalk@^2.0.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+cheerio@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
+
 ci-info@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
@@ -1144,6 +1163,10 @@ color-convert@^1.9.0:
 color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+
+colors@0.5.x:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
 
 combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.6"
@@ -1207,11 +1230,24 @@ cryptiles@3.x.x:
   dependencies:
     boom "5.x.x"
 
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
 css-vendor@^0.3.8:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-0.3.8.tgz#6421cfd3034ce664fe7673972fd0119fc28941fa"
   dependencies:
     is-in-browser "^1.0.2"
+
+css-what@2.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
@@ -1323,24 +1359,54 @@ diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+
 dom-helpers@^3.2.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
-dom-testing-library@^1.0.0:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-1.7.1.tgz#32028cc1e913109fb300e74cec4164f1dd65f8c5"
+dom-serializer@0, dom-serializer@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
   dependencies:
-    jest-dom "^1.0.0"
-    mutationobserver-shim "^0.3.2"
-    pretty-format "^22.4.3"
-    wait-for-expect "^0.4.0"
+    domelementtype "~1.1.1"
+    entities "~1.1.1"
+
+domelementtype@1, domelementtype@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+
+domelementtype@~1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
 
 domexception@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
   dependencies:
     webidl-conversions "^4.0.2"
+
+domhandler@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
+  dependencies:
+    domelementtype "1"
+
+domutils@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -1358,13 +1424,64 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
+entities@^1.1.1, entities@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+enzyme-adapter-react-16@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz#a8f4278b47e082fbca14f5bfb1ee50ee650717b4"
+  dependencies:
+    enzyme-adapter-utils "^1.3.0"
+    lodash "^4.17.4"
+    object.assign "^4.0.4"
+    object.values "^1.0.4"
+    prop-types "^15.6.0"
+    react-reconciler "^0.7.0"
+    react-test-renderer "^16.0.0-0"
+
+enzyme-adapter-utils@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz#d6c85756826c257a8544d362cc7a67e97ea698c7"
+  dependencies:
+    lodash "^4.17.4"
+    object.assign "^4.0.4"
+    prop-types "^15.6.0"
+
+enzyme-to-json@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.3.tgz#ede45938fb309cd87ebd4386f60c754525515a07"
+  dependencies:
+    lodash "^4.17.4"
+
+enzyme@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.3.0.tgz#0971abd167f2d4bf3f5bd508229e1c4b6dc50479"
+  dependencies:
+    cheerio "^1.0.0-rc.2"
+    function.prototype.name "^1.0.3"
+    has "^1.0.1"
+    is-boolean-object "^1.0.0"
+    is-callable "^1.1.3"
+    is-number-object "^1.0.3"
+    is-string "^1.0.4"
+    is-subset "^0.1.1"
+    lodash "^4.17.4"
+    object-inspect "^1.5.0"
+    object-is "^1.0.1"
+    object.assign "^4.1.0"
+    object.entries "^1.0.4"
+    object.values "^1.0.4"
+    raf "^3.4.0"
+    rst-selector-parser "^2.2.3"
+
 error-ex@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.5.1:
+es-abstract@^1.5.1, es-abstract@^1.6.1:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.11.0.tgz#cce87d518f0496893b1a30cd8461835535480681"
   dependencies:
@@ -1655,9 +1772,17 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.0.2, function-bind@^1.1.1:
+function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+
+function.prototype.name@^1.0.3:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.0.tgz#8bd763cc0af860a859cc5d49384d74b932cd2327"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    is-callable "^1.1.3"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -1788,6 +1913,10 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -1872,6 +2001,17 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+htmlparser2@^3.9.1:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -1920,7 +2060,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@~2.0.0, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -1953,6 +2093,10 @@ is-accessor-descriptor@^1.0.0:
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+
+is-boolean-object@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
 
 is-buffer@^1.1.5:
   version "1.1.6"
@@ -2064,6 +2208,10 @@ is-in-browser@^1.0.2, is-in-browser@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
 
+is-number-object@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -2109,6 +2257,14 @@ is-regex@^1.0.4:
 is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-string@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.4.tgz#cc3a9b69857d621e963725a24caeec873b826e64"
+
+is-subset@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
 
 is-symbol@^1.0.1:
   version "1.0.1"
@@ -2308,12 +2464,6 @@ jest-docblock@^22.4.3:
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-22.4.3.tgz#50886f132b42b280c903c592373bb6e93bb68b19"
   dependencies:
     detect-newline "^2.1.0"
-
-jest-dom@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/jest-dom/-/jest-dom-1.0.0.tgz#775bbfc532e72adf6dfa589fc7cb057e196faff5"
-  dependencies:
-    jest-matcher-utils "^22.4.3"
 
 jest-environment-jsdom@^22.4.3:
   version "22.4.3"
@@ -2728,11 +2878,15 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.flattendeep@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@4.17.5, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4:
+lodash@4.17.5, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
@@ -2870,10 +3024,6 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-mutationobserver-shim@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#f4d5dae7a4971a2207914fb5a90ebd514b65acca"
-
 nan@^2.3.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
@@ -2898,6 +3048,15 @@ nanomatch@^1.2.9:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+nearley@^2.7.10:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.13.0.tgz#6e7b0f4e68bfc3e74c99eaef2eda39e513143439"
+  dependencies:
+    nomnom "~1.6.2"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
+    semver "^5.4.1"
 
 no-scroll@^2.1.0:
   version "2.1.0"
@@ -2939,6 +3098,13 @@ node-pre-gyp@^0.6.39:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
+nomnom@~1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
+  dependencies:
+    colors "0.5.x"
+    underscore "~1.4.4"
+
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
@@ -2976,6 +3142,12 @@ npmlog@^4.0.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
+nth-check@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
+  dependencies:
+    boolbase "~1.0.0"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -3000,7 +3172,15 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-keys@^1.0.8:
+object-inspect@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.5.0.tgz#9d876c11e40f485c79215670281b767488f9bfe3"
+
+object-is@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
+
+object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
@@ -3009,6 +3189,24 @@ object-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   dependencies:
     isobject "^3.0.0"
+
+object.assign@^4.0.4, object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
+
+object.entries@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
@@ -3029,6 +3227,15 @@ object.pick@^1.3.0:
   resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
   dependencies:
     isobject "^3.0.1"
+
+object.values@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.0.4.tgz#e524da09b4f66ff05df457546ec72ac99f13069a"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
@@ -3115,6 +3322,12 @@ parse-json@^2.2.0:
 parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  dependencies:
+    "@types/node" "*"
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -3243,6 +3456,23 @@ qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
+raf@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
+  dependencies:
+    performance-now "^2.1.0"
+
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
@@ -3278,6 +3508,10 @@ react-dom@^16.3.1:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-is@^16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.1.tgz#ee66e6d8283224a83b3030e110056798488359ba"
+
 react-jss@^8.1.0:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/react-jss/-/react-jss-8.4.0.tgz#7cb43d85dea56afafc8f0fd072ae27fcc0518950"
@@ -3294,6 +3528,15 @@ react-minimalist-portal@^2.1.1:
   dependencies:
     prop-types "^15.6.0"
 
+react-reconciler@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.7.0.tgz#9614894103e5f138deeeb5eabaf3ee80eb1d026d"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
 react-responsive-modal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/react-responsive-modal/-/react-responsive-modal-2.0.1.tgz#4943446d861a417c172981c47bd512be97de17c8"
@@ -3305,12 +3548,14 @@ react-responsive-modal@^2.0.1:
     react-minimalist-portal "^2.1.1"
     react-transition-group "^2.2.1"
 
-react-testing-library@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-2.1.1.tgz#1d7eb5002823eeedca4c247cdfe8450cfbd4f3b8"
+react-test-renderer@^16.0.0-0:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.1.tgz#d9257936d8535bd40f57f3d5a84e7b0452fb17f2"
   dependencies:
-    dom-testing-library "^1.0.0"
-    wait-for-expect "0.4.0"
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.3.1"
 
 react-transition-group@^2.2.1:
   version "2.3.0"
@@ -3346,7 +3591,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.1.4:
+readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -3538,6 +3783,13 @@ rimraf@2, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
+
+rst-selector-parser@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"
+  dependencies:
+    lodash.flattendeep "^4.4.0"
+    nearley "^2.7.10"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -3976,6 +4228,10 @@ uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
+underscore@~1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
+
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -4041,10 +4297,6 @@ w3c-hr-time@^1.0.1:
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
   dependencies:
     browser-process-hrtime "^0.1.2"
-
-wait-for-expect@0.4.0, wait-for-expect@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-0.4.0.tgz#341c96ab89d6102a0169a9be6cd0de354de92c17"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Refactor the tests using `react-testing-library` to use `enzyme`.

#### What problem is this solving?
The `react-testing-library` is too restricted to the methods it offers to do testing, and the `enzyme` library is more complete.

#### How should this be manually tested?
Run `yarn test` or `npm t`.

#### Screenshots or example usage
N/A

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly
- [x] Changes or additions to the testing environment

