### PR TITLE
Return the 3 level of categories and just map when defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Return the 3 level of categories and just map when defined
 
 ## [0.2.2] - 2018-07-25
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.3] - 2018-08-07
 ### Fixed
 - Return the 3 level of categories and just map when defined
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "category-menu",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "title": "Category Menu",
   "description": "Displays the categories for the store in a menu",
   "defaultLocale": "pt-BR",

--- a/react/components/CategorySubMenuItems.js
+++ b/react/components/CategorySubMenuItems.js
@@ -28,22 +28,24 @@ export default class CategorySubMenuItems extends Component {
             {name}
           </Link>
         )}
-        <ul className="vtex-category-sub-menu__items list ma0 pa0 f6">
-          {categories.map(category => (
-            <li
-              key={category.id}
-              className="vtex-category-sub-menu__item lh-copy"
-            >
-              <Link
-                page="store/category"
-                params={{ ...params, category: category.slug }}
-                className="no-underline underline-hover"
+        {categories && (
+          <ul className="vtex-category-sub-menu__items list ma0 pa0 f6">
+            {categories.map(category => (
+              <li
+                key={category.id}
+                className="vtex-category-sub-menu__item lh-copy"
               >
-                {category.name}
-              </Link>
-            </li>
-          ))}
-        </ul>
+                <Link
+                  page="store/category"
+                  params={{ ...params, category: category.slug }}
+                  className="no-underline underline-hover"
+                >
+                  {category.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     )
   }

--- a/react/queries/categoriesQuery.gql
+++ b/react/queries/categoriesQuery.gql
@@ -11,6 +11,12 @@ query {
       href
       slug
       hasChildren
+      children {
+        id
+        name
+        href
+        slug
+      }
     }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Return the 3 level of categories if exists and just map the children when is defined

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

