### PR TITLE
Remove widths to match page default padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Remove widths to match page default padding.
 
 ## [1.2.0] - 2018-09-17
 ### Added

--- a/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
@@ -114,10 +114,10 @@ exports[`CategoryMenu component should match snapshot 1`] = `
       showPromotionCategory={false}
     >
       <div
-        className="vtex-category-menu bg-white dn flex-m justify-center w-100"
+        className="vtex-category-menu bg-white dn flex-m justify-center"
       >
         <div
-          className="vtex-category-menu__container flex flex-wrap justify-center items-end h3 w-100 w-90-l w-80-xl ph3-s ph7-m ph6-xl f6 overflow-hidden"
+          className="vtex-category-menu__container flex flex-wrap justify-center items-end h3 f6 overflow-hidden"
         >
           <CategoryItem
             category={

--- a/react/index.js
+++ b/react/index.js
@@ -1,5 +1,3 @@
-import './global.css'
-
 import PropTypes from 'prop-types'
 import React, { Component, Fragment } from 'react'
 import { graphql } from 'react-apollo'
@@ -10,6 +8,8 @@ import SideBar from './components/SideBar'
 import HamburguerIcon from './images/HamburguerIcon'
 import { categoryPropType } from './propTypes'
 import getCategories from './queries/categoriesQuery.gql'
+
+import './global.css'
 
 const MAX_NUMBER_OF_MENUS = 6
 

--- a/react/index.js
+++ b/react/index.js
@@ -1,17 +1,17 @@
-import React, { Component, Fragment } from 'react'
-import PropTypes from 'prop-types'
-import { injectIntl, intlShape } from 'react-intl'
-import { graphql } from 'react-apollo'
+import './global.css'
 
-import getCategories from './queries/categoriesQuery.gql'
-import { categoryPropType } from './propTypes'
+import PropTypes from 'prop-types'
+import React, { Component, Fragment } from 'react'
+import { graphql } from 'react-apollo'
+import { injectIntl, intlShape } from 'react-intl'
+
 import CategoryItem from './components/CategoryItem'
 import SideBar from './components/SideBar'
 import HamburguerIcon from './images/HamburguerIcon'
+import { categoryPropType } from './propTypes'
+import getCategories from './queries/categoriesQuery.gql'
 
 const MAX_NUMBER_OF_MENUS = 6
-
-import './global.css'
 
 /**
  * Component that represents the menu containing the categories of the store
@@ -85,8 +85,8 @@ class CategoryMenu extends Component {
       )
     }
     return (
-      <div className="vtex-category-menu bg-white dn flex-m justify-center w-100">
-        <div className="vtex-category-menu__container flex flex-wrap justify-center items-end h3 w-100 w-90-l w-80-xl ph3-s ph7-m ph6-xl f6 overflow-hidden">
+      <div className="vtex-category-menu bg-white dn flex-m justify-center">
+        <div className="vtex-category-menu__container flex flex-wrap justify-center items-end h3 f6 overflow-hidden">
           <CategoryItem noRedirect category={{
             children: categories,
             name: intl.formatMessage({ id: 'category-menu.departments.title' }),


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove widths to match page default padding

#### What problem is this solving?

Width definitions were overriding padding definition.

#### How should this be manually tested?

[Access the workspace](https://padding--storecomponents.myvtex.com/) and resize the screen.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/15948386/45642989-5b065a00-ba90-11e8-88aa-bfabda4c9faf.png)
![image](https://user-images.githubusercontent.com/15948386/45643003-622d6800-ba90-11e8-8823-06d05427ec88.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

