### PR TITLE
Fix scroll being prevented on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.2.1] - 2018-09-19
 ### Changed
 - Remove widths to match page default padding.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Remove widths to match page default padding.
 
+### Fixed
+- Scroll being prevented on mobile.
+
 ## [1.2.0] - 2018-09-17
 ### Added
 - Add animation to mobile sidebar.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "category-menu",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "title": "Category Menu",
   "description": "Displays the categories for the store in a menu",
   "defaultLocale": "pt-BR",

--- a/react/components/SideBar.js
+++ b/react/components/SideBar.js
@@ -6,7 +6,7 @@ import { Animation } from 'vtex.store-components'
 import { IconCaretLeft } from 'vtex.styleguide'
 import SideBarItem from './SideBarItem'
 
-const OPEN_SIDEBAR_CLASS = 'vtex-category-menu-sidebar-open'
+const OPEN_SIDEBAR_CLASS = 'vtex-menu-sidebar-open'
 
 export default class SideBar extends Component {
   static propTypes = {

--- a/react/components/SideBar.js
+++ b/react/components/SideBar.js
@@ -1,9 +1,12 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
+import classNames from 'classnames'
 
 import { Animation } from 'vtex.store-components'
 import { IconCaretLeft } from 'vtex.styleguide'
 import SideBarItem from './SideBarItem'
+
+const OPEN_SIDEBAR_CLASS = 'vtex-category-menu-sidebar-open'
 
 export default class SideBar extends Component {
   static propTypes = {
@@ -23,12 +26,24 @@ export default class SideBar extends Component {
     onClose: () => {},
   }
 
+  updateComponent() {
+    if (this.props.visible) {
+      document.body.classList.add(OPEN_SIDEBAR_CLASS)
+    } else {
+      document.body.classList.remove(OPEN_SIDEBAR_CLASS)
+    }
+  }
+
   componentDidMount() {
-    document.body.classList.add('overflow-y-hidden')
+    this.updateComponent()
+  }
+
+  componentDidUpdate() {
+    this.updateComponent()
   }
 
   componentWillUnmount() {
-    document.body.classList.remove('overflow-y-hidden')
+    document.body.classList.remove(OPEN_SIDEBAR_CLASS)
   }
 
   handleOutsideClick = () => {
@@ -38,21 +53,21 @@ export default class SideBar extends Component {
   render() {
     const { visible } = this.props
 
+    const scrimClasses = classNames('vtex-menu-sidebar__scrim fixed dim bg-near-black top-0 z-1 w-100 vh-100 o-40', {
+      dn: !visible,
+    })
+
     return (
       <Fragment>
-        {visible && (
-          <div
-            className="vtex-menu-sidebar__foreground fixed bg-near-black top-0 z-1 w-100 vh-100 o-40"
-            onClick={() => this.props.onClose()}
-          />
-        )}
+        <div style={{ willChange: 'opacity' }} className={scrimClasses} onClick={this.props.onClose} />
         <Animation
           isActive={visible}
           type="drawerRight"
-          className="fixed vh-100 w-80 left-0 top-0 z-999"
+          className="fixed vh-100 w-80 left-0 top-0 z-max"
         >
-          <div className="vtex-menu-sidebar w-100 fixed bg-white vh-100 left-0 top-0 z-999">
-            <div className="vtex-menu-sidebar__header flex justify-between items-center pa4 pl6 shadow-5 pointer"
+          <div className="vtex-menu-sidebar w-100 bg-white vh-100">
+            <div
+              className="vtex-menu-sidebar__header flex justify-between items-center pa4 pl6 shadow-5 pointer"
               onClick={() => this.props.onClose()}
             >
               <span className="f4 fw5 dark-gray">{this.props.title}</span>
@@ -72,8 +87,6 @@ export default class SideBar extends Component {
             </div>
           </div>
         </Animation>
-            
-          
       </Fragment>
     )
   }

--- a/react/global.css
+++ b/react/global.css
@@ -10,3 +10,9 @@
 .vtex-menu-sidebar__content {
   height: calc(100% - 2.625rem);
 }
+
+@media only screen and (max-width: 40rem) {
+  body.vtex-category-menu-sidebar-open {
+    overflow-y: hidden;
+  }
+}

--- a/react/global.css
+++ b/react/global.css
@@ -12,7 +12,7 @@
 }
 
 @media only screen and (max-width: 40rem) {
-  body.vtex-category-menu-sidebar-open {
+  body.vtex-menu-sidebar-open {
     overflow-y: hidden;
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -5,7 +5,8 @@
     "test": "vtex-scripts test"
   },
   "dependencies": {
-    "@vtex/styleguide": "^2.0.0-rc.39"
+    "@vtex/styleguide": "^2.0.0-rc.39",
+    "classnames": "^2.2.6"
   },
   "devDependencies": {
     "@vtex/vtex-scripts": "^0.4.2",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1188,6 +1188,10 @@ classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add logic before adding the class `vtex-menu-sidebar-open` (was `overflow-y-hidden` before) to the body and fixes some performance issues with the sidebar scrim.

#### What problem is this solving?
The scroll was impossible on mobile due to this issue, and when the sidebar was opened the animation was staggering.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/), access with a mobile device.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

