### PR TITLE
Changed sidebar header to match minicart sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Sidebar header now matches the minicart one.
 
 ## [1.2.1] - 2018-09-19
 ### Changed
 - Remove widths to match page default padding.
-- Sidebar header now matches the minicart one.
 
 ### Fixed
 - Scroll being prevented on mobile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Remove widths to match page default padding.
-
-### Fixed
 - Sidebar header now matches the minicart one.
 
 ## [1.2.0] - 2018-09-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Remove widths to match page default padding.
 
+### Fixed
+- Sidebar header now matches the minicart one.
+
 ## [1.2.0] - 2018-09-17
 ### Added
 - Add animation to mobile sidebar.

--- a/react/components/SideBar.js
+++ b/react/components/SideBar.js
@@ -67,7 +67,7 @@ export default class SideBar extends Component {
         >
           <div className="vtex-menu-sidebar w-100 bg-white vh-100">
             <div
-              className="vtex-menu-sidebar__header flex justify-between items-center pa4 pl6 shadow-5 pointer h3"
+              className="vtex-menu-sidebar__header flex justify-between items-center pa4 pl6 shadow-4 pointer h3"
               onClick={() => this.props.onClose()}
             >
               <span className="f4 fw5 dark-gray">{this.props.title}</span>

--- a/react/components/SideBar.js
+++ b/react/components/SideBar.js
@@ -67,7 +67,7 @@ export default class SideBar extends Component {
         >
           <div className="vtex-menu-sidebar w-100 bg-white vh-100">
             <div
-              className="vtex-menu-sidebar__header flex justify-between items-center pa4 pl6 shadow-5 pointer"
+              className="vtex-menu-sidebar__header flex justify-between items-center pa4 pl6 shadow-5 pointer h3"
               onClick={() => this.props.onClose()}
             >
               <span className="f4 fw5 dark-gray">{this.props.title}</span>

--- a/react/global.css
+++ b/react/global.css
@@ -7,10 +7,6 @@
   width: 14.28%;
 }
 
-.vtex-category-menu--mobile .vtex-menu-sidebar__header {
-  height: 4rem;
-}
-
 .vtex-category-menu--mobile .vtex-menu-sidebar__content {
   height: calc(100% - 2.625rem);
 }

--- a/react/global.css
+++ b/react/global.css
@@ -7,6 +7,10 @@
   width: 14.28%;
 }
 
-.vtex-menu-sidebar__content {
+.vtex-category-menu--mobile .vtex-menu-sidebar__header {
+  height: 4rem;
+}
+
+.vtex-category-menu--mobile .vtex-menu-sidebar__content {
   height: calc(100% - 2.625rem);
 }

--- a/react/index.js
+++ b/react/index.js
@@ -72,7 +72,7 @@ class CategoryMenu extends Component {
     const categoriesSliced = categories.slice(0, MAX_NUMBER_OF_MENUS)
     if (mobileMode) {
       return (
-        <Fragment>
+        <div className="vtex-category-menu vtex-category-menu--mobile">
           <SideBar
             visible={this.state.sideBarVisible}
             title={intl.formatMessage({ id: 'category-menu.departments.title' })}
@@ -81,7 +81,7 @@ class CategoryMenu extends Component {
           <div className="flex pa4 pointer" onClick={this.handleSidebarToggle}>
             <HamburguerIcon />
           </div>
-        </Fragment>
+        </div>
       )
     }
     return (


### PR DESCRIPTION
#### What is the purpose of this pull request?

Changed sidebar header to match minicart sidebar

#### What problem is this solving?

Category menu sidebar header didn't match the minicart one.

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/) in mobile mode and see they match.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/45768412-28389f00-bc13-11e8-83b3-edba2b17a59e.png)

![image](https://user-images.githubusercontent.com/15948386/45768426-31297080-bc13-11e8-80cc-2d718fe1c310.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

