### PR TITLE
Replace tachyons colors and typography with design tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Replace typography and color classes with design tokens.
 
 ## [1.6.0] - 2018-11-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.0] - 2018-11-20
 ### Changed
 - Replace typography and color classes with design tokens.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "category-menu",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "title": "Category Menu",
   "description": "Displays the categories for the store in a menu",
   "defaultLocale": "pt-BR",

--- a/react/__tests__/__snapshots__/CategoryItem.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryItem.test.js.snap
@@ -7,7 +7,7 @@ exports[`CategoryItem component should match snapshot 1`] = `
   onMouseLeave={[Function]}
 >
   <Link
-    className="w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
+    className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
     onClick={[Function]}
     page="store/department"
     params={

--- a/react/__tests__/__snapshots__/CategoryItem.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryItem.test.js.snap
@@ -7,7 +7,7 @@ exports[`CategoryItem component should match snapshot 1`] = `
   onMouseLeave={[Function]}
 >
   <Link
-    className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
+    className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
     onClick={[Function]}
     page="store/department"
     params={

--- a/react/__tests__/__snapshots__/CategoryItem.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryItem.test.js.snap
@@ -7,7 +7,7 @@ exports[`CategoryItem component should match snapshot 1`] = `
   onMouseLeave={[Function]}
 >
   <Link
-    className="w-100 pv5 mh6 no-underline f6 outline-0 db tc truncate bb bw1 gray b--transparent"
+    className="w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
     onClick={[Function]}
     page="store/department"
     params={

--- a/react/__tests__/__snapshots__/CategoryItem.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryItem.test.js.snap
@@ -7,7 +7,7 @@ exports[`CategoryItem component should match snapshot 1`] = `
   onMouseLeave={[Function]}
 >
   <Link
-    className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
+    className="w-100 pv5 mh6 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
     onClick={[Function]}
     page="store/department"
     params={

--- a/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
@@ -156,7 +156,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
         className="vtex-category-menu bg-base dn flex-m justify-center"
       >
         <div
-          className="vtex-category-menu__container flex flex-wrap justify-center items-end t-body overflow-hidden"
+          className="vtex-category-menu__container flex flex-wrap justify-center items-end t-action overflow-hidden"
         >
           <CategoryItem
             category={
@@ -199,7 +199,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
               onMouseLeave={[Function]}
             >
               <a
-                className="w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
+                className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
                 href="#"
               >
                 DEPARTMENTS
@@ -256,7 +256,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                         key="1"
                       >
                         <Link
-                          className="vtex-category-menu__link-level-2 db t-action-mini no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                          className="vtex-category-menu__link-level-2 db t-action--small no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                           onClick={[Function]}
                           page="store/department"
                           params={
@@ -266,7 +266,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                           }
                         >
                           <a
-                            className="vtex-category-menu__link-level-2 db t-action-mini no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                            className="vtex-category-menu__link-level-2 db t-action--small no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                             href="/category-1/s"
                           >
                             CATEGORY 1
@@ -278,7 +278,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                         key="2"
                       >
                         <Link
-                          className="vtex-category-menu__link-level-2 db t-action-mini no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                          className="vtex-category-menu__link-level-2 db t-action--small no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                           onClick={[Function]}
                           page="store/department"
                           params={
@@ -288,7 +288,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                           }
                         >
                           <a
-                            className="vtex-category-menu__link-level-2 db t-action-mini no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                            className="vtex-category-menu__link-level-2 db t-action--small no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                             href="/category-2/s"
                           >
                             CATEGORY 2
@@ -300,7 +300,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                         key="3"
                       >
                         <Link
-                          className="vtex-category-menu__link-level-2 db t-action-mini no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                          className="vtex-category-menu__link-level-2 db t-action--small no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                           onClick={[Function]}
                           page="store/department"
                           params={
@@ -310,7 +310,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                           }
                         >
                           <a
-                            className="vtex-category-menu__link-level-2 db t-action-mini no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                            className="vtex-category-menu__link-level-2 db t-action--small no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                             href="/category-3/s"
                           >
                             CATEGORY 3
@@ -346,7 +346,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                 onMouseLeave={[Function]}
               >
                 <Link
-                  className="w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
+                  className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
                   onClick={[Function]}
                   page="store/department"
                   params={
@@ -356,7 +356,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   }
                 >
                   <a
-                    className="w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
+                    className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
                     href="/category-1/s"
                   >
                     CATEGORY 1
@@ -388,7 +388,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                 onMouseLeave={[Function]}
               >
                 <Link
-                  className="w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
+                  className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
                   onClick={[Function]}
                   page="store/department"
                   params={
@@ -398,7 +398,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   }
                 >
                   <a
-                    className="w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
+                    className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
                     href="/category-2/s"
                   >
                     CATEGORY 2
@@ -430,7 +430,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                 onMouseLeave={[Function]}
               >
                 <Link
-                  className="w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
+                  className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
                   onClick={[Function]}
                   page="store/department"
                   params={
@@ -440,7 +440,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   }
                 >
                   <a
-                    className="w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
+                    className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
                     href="/category-3/s"
                   >
                     CATEGORY 3

--- a/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
@@ -199,7 +199,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
               onMouseLeave={[Function]}
             >
               <a
-                className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
+                className="w-100 pv5 mh6 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
                 href="#"
               >
                 DEPARTMENTS
@@ -256,7 +256,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                         key="1"
                       >
                         <Link
-                          className="vtex-category-menu__link-level-2 db t-action--small link no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                          className="vtex-category-menu__link-level-2 db link no-underline pa4 outline-0 tl t-small truncate c-on-base underline-hover"
                           onClick={[Function]}
                           page="store/department"
                           params={
@@ -266,7 +266,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                           }
                         >
                           <a
-                            className="vtex-category-menu__link-level-2 db t-action--small link no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                            className="vtex-category-menu__link-level-2 db link no-underline pa4 outline-0 tl t-small truncate c-on-base underline-hover"
                             href="/category-1/s"
                           >
                             CATEGORY 1
@@ -278,7 +278,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                         key="2"
                       >
                         <Link
-                          className="vtex-category-menu__link-level-2 db t-action--small link no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                          className="vtex-category-menu__link-level-2 db link no-underline pa4 outline-0 tl t-small truncate c-on-base underline-hover"
                           onClick={[Function]}
                           page="store/department"
                           params={
@@ -288,7 +288,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                           }
                         >
                           <a
-                            className="vtex-category-menu__link-level-2 db t-action--small link no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                            className="vtex-category-menu__link-level-2 db link no-underline pa4 outline-0 tl t-small truncate c-on-base underline-hover"
                             href="/category-2/s"
                           >
                             CATEGORY 2
@@ -300,7 +300,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                         key="3"
                       >
                         <Link
-                          className="vtex-category-menu__link-level-2 db t-action--small link no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                          className="vtex-category-menu__link-level-2 db link no-underline pa4 outline-0 tl t-small truncate c-on-base underline-hover"
                           onClick={[Function]}
                           page="store/department"
                           params={
@@ -310,7 +310,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                           }
                         >
                           <a
-                            className="vtex-category-menu__link-level-2 db t-action--small link no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                            className="vtex-category-menu__link-level-2 db link no-underline pa4 outline-0 tl t-small truncate c-on-base underline-hover"
                             href="/category-3/s"
                           >
                             CATEGORY 3
@@ -346,7 +346,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                 onMouseLeave={[Function]}
               >
                 <Link
-                  className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
+                  className="w-100 pv5 mh6 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
                   onClick={[Function]}
                   page="store/department"
                   params={
@@ -356,7 +356,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   }
                 >
                   <a
-                    className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
+                    className="w-100 pv5 mh6 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
                     href="/category-1/s"
                   >
                     CATEGORY 1
@@ -388,7 +388,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                 onMouseLeave={[Function]}
               >
                 <Link
-                  className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
+                  className="w-100 pv5 mh6 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
                   onClick={[Function]}
                   page="store/department"
                   params={
@@ -398,7 +398,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   }
                 >
                   <a
-                    className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
+                    className="w-100 pv5 mh6 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
                     href="/category-2/s"
                   >
                     CATEGORY 2
@@ -430,7 +430,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                 onMouseLeave={[Function]}
               >
                 <Link
-                  className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
+                  className="w-100 pv5 mh6 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
                   onClick={[Function]}
                   page="store/department"
                   params={
@@ -440,7 +440,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   }
                 >
                   <a
-                    className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
+                    className="w-100 pv5 mh6 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
                     href="/category-3/s"
                   >
                     CATEGORY 3

--- a/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
@@ -156,7 +156,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
         className="vtex-category-menu bg-base dn flex-m justify-center"
       >
         <div
-          className="vtex-category-menu__container flex flex-wrap justify-center items-end overflow-hidden"
+          className="vtex-category-menu__container flex flex-wrap justify-center items-end t-action overflow-hidden"
         >
           <CategoryItem
             category={

--- a/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
@@ -153,10 +153,10 @@ exports[`CategoryMenu component should match snapshot 1`] = `
       showSubcategories={true}
     >
       <div
-        className="vtex-category-menu bg-white dn flex-m justify-center"
+        className="vtex-category-menu bg-base dn flex-m justify-center"
       >
         <div
-          className="vtex-category-menu__container flex flex-wrap justify-center items-end f6 overflow-hidden"
+          className="vtex-category-menu__container flex flex-wrap justify-center items-end t-body overflow-hidden"
         >
           <CategoryItem
             category={
@@ -199,7 +199,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
               onMouseLeave={[Function]}
             >
               <a
-                className="w-100 pv5 mh6 no-underline f6 outline-0 db tc truncate bb bw1 gray b--transparent"
+                className="w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
                 href="#"
               >
                 DEPARTMENTS
@@ -246,7 +246,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   showSecondLevel={true}
                 >
                   <div
-                    className="vtex-category-menu__item-container w-100 bg-white pb2 overflow-y-auto bw1 bb b--light-gray"
+                    className="vtex-category-menu__item-container w-100 bg-base pb2 overflow-y-auto bw1 bb b--muted-3"
                   >
                     <div
                       className="w-100 w-90-l w-80-xl center ph3-s ph7-m ph6-xl"
@@ -256,7 +256,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                         key="1"
                       >
                         <Link
-                          className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                          className="vtex-category-menu__link-level-2 db t-action-mini no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                           onClick={[Function]}
                           page="store/department"
                           params={
@@ -266,7 +266,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                           }
                         >
                           <a
-                            className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                            className="vtex-category-menu__link-level-2 db t-action-mini no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                             href="/category-1/s"
                           >
                             CATEGORY 1
@@ -278,7 +278,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                         key="2"
                       >
                         <Link
-                          className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                          className="vtex-category-menu__link-level-2 db t-action-mini no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                           onClick={[Function]}
                           page="store/department"
                           params={
@@ -288,7 +288,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                           }
                         >
                           <a
-                            className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                            className="vtex-category-menu__link-level-2 db t-action-mini no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                             href="/category-2/s"
                           >
                             CATEGORY 2
@@ -300,7 +300,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                         key="3"
                       >
                         <Link
-                          className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                          className="vtex-category-menu__link-level-2 db t-action-mini no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                           onClick={[Function]}
                           page="store/department"
                           params={
@@ -310,7 +310,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                           }
                         >
                           <a
-                            className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                            className="vtex-category-menu__link-level-2 db t-action-mini no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                             href="/category-3/s"
                           >
                             CATEGORY 3
@@ -346,7 +346,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                 onMouseLeave={[Function]}
               >
                 <Link
-                  className="w-100 pv5 mh6 no-underline f6 outline-0 db tc truncate bb bw1 gray b--transparent"
+                  className="w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
                   onClick={[Function]}
                   page="store/department"
                   params={
@@ -356,7 +356,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   }
                 >
                   <a
-                    className="w-100 pv5 mh6 no-underline f6 outline-0 db tc truncate bb bw1 gray b--transparent"
+                    className="w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
                     href="/category-1/s"
                   >
                     CATEGORY 1
@@ -388,7 +388,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                 onMouseLeave={[Function]}
               >
                 <Link
-                  className="w-100 pv5 mh6 no-underline f6 outline-0 db tc truncate bb bw1 gray b--transparent"
+                  className="w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
                   onClick={[Function]}
                   page="store/department"
                   params={
@@ -398,7 +398,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   }
                 >
                   <a
-                    className="w-100 pv5 mh6 no-underline f6 outline-0 db tc truncate bb bw1 gray b--transparent"
+                    className="w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
                     href="/category-2/s"
                   >
                     CATEGORY 2
@@ -430,7 +430,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                 onMouseLeave={[Function]}
               >
                 <Link
-                  className="w-100 pv5 mh6 no-underline f6 outline-0 db tc truncate bb bw1 gray b--transparent"
+                  className="w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
                   onClick={[Function]}
                   page="store/department"
                   params={
@@ -440,7 +440,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   }
                 >
                   <a
-                    className="w-100 pv5 mh6 no-underline f6 outline-0 db tc truncate bb bw1 gray b--transparent"
+                    className="w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
                     href="/category-3/s"
                   >
                     CATEGORY 3

--- a/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
@@ -156,7 +156,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
         className="vtex-category-menu bg-base dn flex-m justify-center"
       >
         <div
-          className="vtex-category-menu__container flex flex-wrap justify-center items-end t-action overflow-hidden"
+          className="vtex-category-menu__container flex flex-wrap justify-center items-end overflow-hidden"
         >
           <CategoryItem
             category={
@@ -199,7 +199,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
               onMouseLeave={[Function]}
             >
               <a
-                className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
+                className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
                 href="#"
               >
                 DEPARTMENTS
@@ -256,7 +256,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                         key="1"
                       >
                         <Link
-                          className="vtex-category-menu__link-level-2 db t-action--small no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                          className="vtex-category-menu__link-level-2 db t-action--small link no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                           onClick={[Function]}
                           page="store/department"
                           params={
@@ -266,7 +266,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                           }
                         >
                           <a
-                            className="vtex-category-menu__link-level-2 db t-action--small no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                            className="vtex-category-menu__link-level-2 db t-action--small link no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                             href="/category-1/s"
                           >
                             CATEGORY 1
@@ -278,7 +278,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                         key="2"
                       >
                         <Link
-                          className="vtex-category-menu__link-level-2 db t-action--small no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                          className="vtex-category-menu__link-level-2 db t-action--small link no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                           onClick={[Function]}
                           page="store/department"
                           params={
@@ -288,7 +288,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                           }
                         >
                           <a
-                            className="vtex-category-menu__link-level-2 db t-action--small no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                            className="vtex-category-menu__link-level-2 db t-action--small link no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                             href="/category-2/s"
                           >
                             CATEGORY 2
@@ -300,7 +300,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                         key="3"
                       >
                         <Link
-                          className="vtex-category-menu__link-level-2 db t-action--small no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                          className="vtex-category-menu__link-level-2 db t-action--small link no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                           onClick={[Function]}
                           page="store/department"
                           params={
@@ -310,7 +310,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                           }
                         >
                           <a
-                            className="vtex-category-menu__link-level-2 db t-action--small no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                            className="vtex-category-menu__link-level-2 db t-action--small link no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
                             href="/category-3/s"
                           >
                             CATEGORY 3
@@ -346,7 +346,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                 onMouseLeave={[Function]}
               >
                 <Link
-                  className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
+                  className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
                   onClick={[Function]}
                   page="store/department"
                   params={
@@ -356,7 +356,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   }
                 >
                   <a
-                    className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
+                    className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
                     href="/category-1/s"
                   >
                     CATEGORY 1
@@ -388,7 +388,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                 onMouseLeave={[Function]}
               >
                 <Link
-                  className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
+                  className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
                   onClick={[Function]}
                   page="store/department"
                   params={
@@ -398,7 +398,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   }
                 >
                   <a
-                    className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
+                    className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
                     href="/category-2/s"
                   >
                     CATEGORY 2
@@ -430,7 +430,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                 onMouseLeave={[Function]}
               >
                 <Link
-                  className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
+                  className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
                   onClick={[Function]}
                   page="store/department"
                   params={
@@ -440,7 +440,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   }
                 >
                   <a
-                    className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1 b--transparent"
+                    className="w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
                     href="/category-3/s"
                   >
                     CATEGORY 3

--- a/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
@@ -246,7 +246,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   showSecondLevel={true}
                 >
                   <div
-                    className="vtex-category-menu__item-container w-100 bg-base pb2 overflow-y-auto bw1 bb b--muted-3"
+                    className="vtex-category-menu__item-container w-100 bg-base pb2 bw1 bb b--muted-3"
                   >
                     <div
                       className="w-100 w-90-l w-80-xl center ph3-s ph7-m ph6-xl"

--- a/react/components/CategoryItem.js
+++ b/react/components/CategoryItem.js
@@ -36,7 +36,7 @@ export default class CategoryItem extends Component {
     }
 
     const linkClasses = classNames(
-      'w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1', {
+      'w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1', {
         'b--transparent': !isHover,
         'b--action-primary': isHover,
       }

--- a/react/components/CategoryItem.js
+++ b/react/components/CategoryItem.js
@@ -36,9 +36,9 @@ export default class CategoryItem extends Component {
     }
 
     const linkClasses = classNames(
-      'w-100 pv5 mh6 no-underline f6 outline-0 db tc truncate bb bw1 gray', {
+      'w-100 pv5 mh6 no-underline t-body outline-0 db tc truncate bb bw1 c-muted-1', {
         'b--transparent': !isHover,
-        'b--heavy-blue': isHover,
+        'b--action-primary': isHover,
       }
     )
 

--- a/react/components/CategoryItem.js
+++ b/react/components/CategoryItem.js
@@ -36,7 +36,7 @@ export default class CategoryItem extends Component {
     }
 
     const linkClasses = classNames(
-      'w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1', {
+      'w-100 pv5 mh6 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1', {
         'b--transparent': !isHover,
         'b--action-primary': isHover,
       }

--- a/react/components/CategoryItem.js
+++ b/react/components/CategoryItem.js
@@ -36,7 +36,7 @@ export default class CategoryItem extends Component {
     }
 
     const linkClasses = classNames(
-      'w-100 pv5 mh6 no-underline t-action--small outline-0 db tc truncate bb bw1 c-muted-1', {
+      'w-100 pv5 mh6 no-underline t-action--small outline-0 db tc link truncate bb bw1 c-muted-1', {
         'b--transparent': !isHover,
         'b--action-primary': isHover,
       }

--- a/react/components/ItemContainer.js
+++ b/react/components/ItemContainer.js
@@ -29,7 +29,7 @@ export default class ItemContainer extends Component {
       <Link
         onClick={this.props.onCloseMenu}
         page={parentSlug ? 'store/category' : 'store/department'}
-        className="vtex-category-menu__link-level-2 db t-action-mini no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+        className="vtex-category-menu__link-level-2 db t-action--small no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
         params={params}
       >
         {item.name.toUpperCase()}
@@ -47,7 +47,7 @@ export default class ItemContainer extends Component {
       <Link
         onClick={this.props.onCloseMenu}
         page={parentSlug ? 'store/subcategory' : 'store/category'}
-        className="vtex-category-menu__link-level-3 db pa3 ph5 no-underline outline-0 tl t-action-mini truncate c-muted-1 underline-hover"
+        className="vtex-category-menu__link-level-3 db pa3 ph5 no-underline outline-0 tl t-action--small truncate c-muted-1 underline-hover"
         params={params}
       >
         {subItem.name}

--- a/react/components/ItemContainer.js
+++ b/react/components/ItemContainer.js
@@ -29,7 +29,7 @@ export default class ItemContainer extends Component {
       <Link
         onClick={this.props.onCloseMenu}
         page={parentSlug ? 'store/category' : 'store/department'}
-        className="vtex-category-menu__link-level-2 db t-action--small link no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+        className="vtex-category-menu__link-level-2 db link no-underline pa4 outline-0 tl t-small truncate c-on-base underline-hover"
         params={params}
       >
         {item.name.toUpperCase()}
@@ -47,7 +47,7 @@ export default class ItemContainer extends Component {
       <Link
         onClick={this.props.onCloseMenu}
         page={parentSlug ? 'store/subcategory' : 'store/category'}
-        className="vtex-category-menu__link-level-3 db pa3 ph5 no-underline outline-0 tl link t-action--small truncate c-muted-1 underline-hover"
+        className="vtex-category-menu__link-level-3 db pa3 ph5 no-underline outline-0 tl link t-small truncate c-muted-1 underline-hover"
         params={params}
       >
         {subItem.name}

--- a/react/components/ItemContainer.js
+++ b/react/components/ItemContainer.js
@@ -29,7 +29,7 @@ export default class ItemContainer extends Component {
       <Link
         onClick={this.props.onCloseMenu}
         page={parentSlug ? 'store/category' : 'store/department'}
-        className="vtex-category-menu__link-level-2 db t-action--small no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+        className="vtex-category-menu__link-level-2 db t-action--small link no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
         params={params}
       >
         {item.name.toUpperCase()}
@@ -47,7 +47,7 @@ export default class ItemContainer extends Component {
       <Link
         onClick={this.props.onCloseMenu}
         page={parentSlug ? 'store/subcategory' : 'store/category'}
-        className="vtex-category-menu__link-level-3 db pa3 ph5 no-underline outline-0 tl t-action--small truncate c-muted-1 underline-hover"
+        className="vtex-category-menu__link-level-3 db pa3 ph5 no-underline outline-0 tl link t-action--small truncate c-muted-1 underline-hover"
         params={params}
       >
         {subItem.name}

--- a/react/components/ItemContainer.js
+++ b/react/components/ItemContainer.js
@@ -29,7 +29,7 @@ export default class ItemContainer extends Component {
       <Link
         onClick={this.props.onCloseMenu}
         page={parentSlug ? 'store/category' : 'store/department'}
-        className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+        className="vtex-category-menu__link-level-2 db t-action-mini no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
         params={params}
       >
         {item.name.toUpperCase()}
@@ -47,7 +47,7 @@ export default class ItemContainer extends Component {
       <Link
         onClick={this.props.onCloseMenu}
         page={parentSlug ? 'store/subcategory' : 'store/category'}
-        className="vtex-category-menu__link-level-3 db pa3 ph5 no-underline outline-0 tl f7 truncate gray underline-hover"
+        className="vtex-category-menu__link-level-3 db pa3 ph5 no-underline outline-0 tl t-action-mini truncate c-muted-1 underline-hover"
         params={params}
       >
         {subItem.name}
@@ -57,7 +57,7 @@ export default class ItemContainer extends Component {
 
   render() {
     return (
-      <div className="vtex-category-menu__item-container w-100 bg-white pb2 overflow-y-auto bw1 bb b--light-gray">
+      <div className="vtex-category-menu__item-container w-100 bg-base pb2 overflow-y-auto bw1 bb b--muted-3">
         <div className="w-100 w-90-l w-80-xl center ph3-s ph7-m ph6-xl">
           {this.props.categories.map(category => (
             <div key={category.id} className="fl db pa2">
@@ -66,7 +66,7 @@ export default class ItemContainer extends Component {
                 <Fragment>
                   {this.props.showSecondLevel && category.children.map((subCategory) => (
                     <Fragment key={subCategory.id}>
-                      <span className="flex bt w-90 b--light-gray center"></span>
+                      <span className="flex bt w-90 b--muted-4 center"></span>
                       {this.renderLinkSecondLevel(this.props.parentSlug, category, subCategory)}
                     </Fragment>
                   ))}

--- a/react/components/ItemContainer.js
+++ b/react/components/ItemContainer.js
@@ -57,7 +57,7 @@ export default class ItemContainer extends Component {
 
   render() {
     return (
-      <div className="vtex-category-menu__item-container w-100 bg-base pb2 overflow-y-auto bw1 bb b--muted-3">
+      <div className="vtex-category-menu__item-container w-100 bg-base pb2 bw1 bb b--muted-3">
         <div className="w-100 w-90-l w-80-xl center ph3-s ph7-m ph6-xl">
           {this.props.categories.map(category => (
             <div key={category.id} className="fl db pa2">

--- a/react/components/SideBar.js
+++ b/react/components/SideBar.js
@@ -55,7 +55,7 @@ export default class SideBar extends Component {
   render() {
     const { visible, onClose, showSubcategories } = this.props
 
-    const scrimClasses = classNames('vtex-menu-sidebar__scrim fixed dim bg-near-black top-0 z-1 w-100 vh-100 o-40', {
+    const scrimClasses = classNames('vtex-menu-sidebar__scrim fixed dim bg-base--inverted top-0 z-1 w-100 vh-100 o-40', {
       dn: !visible,
     })
 
@@ -67,18 +67,18 @@ export default class SideBar extends Component {
           type="drawerRight"
           className="fixed vh-100 w-80 left-0 top-0 z-max"
         >
-          <div className="vtex-menu-sidebar w-100 bg-white vh-100">
+          <div className="vtex-menu-sidebar w-100 bg-base vh-100">
             <div
               className="vtex-menu-sidebar__header flex justify-between items-center pa4 pl6 shadow-4 pointer h3"
               onClick={onClose}
             >
-              <span className="f4 fw5 dark-gray">{this.props.title}</span>
+              <span className="t-heading-5 c-on-base">{this.props.title}</span>
               <IconCaretLeft size={13} color="#585959" />
             </div>
             <div className="vtex-menu-sidebar__content shadow-5 overflow-y-auto">
               {this.props.departments.map(department => (
                 <Fragment key={department.id}>
-                  <span className="flex bt w-90 b--light-gray center"></span>
+                  <span className="flex bt w-90 b--muted-4 center"></span>
                   <SideBarItem
                     item={department}
                     linkValues={[department.slug]}

--- a/react/components/SideBarItem.js
+++ b/react/components/SideBarItem.js
@@ -70,13 +70,13 @@ class SideBarItem extends Component {
     const hasChildren = showSubcategories && item.children && item.children.length > 0
     const sideBarItemClasses = classNames(
       'vtex-menu-sidebar__item', {
-        'bg-light-silver mid-gray fw3': treeLevel > 1,
-        'near-black': treeLevel === 1
+        'bg-muted-5 c-on-muted-4': treeLevel > 1,
+        'c-on-base': treeLevel === 1
       }
     )
     const sideBarItemTitleClasses = classNames('', {
-      'ml5' : treeLevel === 3,
-      'ttu' : treeLevel === 1
+      'ml5': treeLevel === 3,
+      'ttu': treeLevel === 1
     })
     return (
       <div className={sideBarItemClasses}>
@@ -88,10 +88,10 @@ class SideBarItem extends Component {
           </span>
           {
             hasChildren && (
-              <span className={treeLevel === 1 ? 'gray' : 'silver'}>
+              <span className={treeLevel === 1 ? 'c-muted-2' : 'c-muted-3'}>
                 {this.state.open
-                  ? <IconCaretUp size={13} color={'currentcolor'}/>
-                  : <IconCaretDown size={13} color={'currentcolor'}/>
+                  ? <IconCaretUp size={13} color={'currentcolor'} />
+                  : <IconCaretDown size={13} color={'currentcolor'} />
                 }
               </span>
             )
@@ -100,7 +100,7 @@ class SideBarItem extends Component {
         {
           hasChildren && (
             <div className="bg-light-silver">
-              {this.state.open && 
+              {this.state.open &&
                 <Fragment>
                   <div className="vtex-menu-sidebar__item bg-muted-5 c-on-muted-3">
                     <div className="flex justify-between items-center pa4 pl6 pointer"
@@ -109,16 +109,16 @@ class SideBarItem extends Component {
                     </div>
                   </div>
                   {item.children.map(child => (
-                  <Fragment key={child.id}>
-                    <span className="flex bt w-90 b--light-gray center"></span>
-                    <SideBarItem
-                      runtime={runtime}
-                      item={child}
-                      linkValues={[...linkValues, child.slug]}
-                      onClose={onClose}
-                      treeLevel={treeLevel + 1}
-                    />
-                  </Fragment>))}
+                    <Fragment key={child.id}>
+                      <span className="flex bt w-90 b--muted-4 center"></span>
+                      <SideBarItem
+                        runtime={runtime}
+                        item={child}
+                        linkValues={[...linkValues, child.slug]}
+                        onClose={onClose}
+                        treeLevel={treeLevel + 1}
+                      />
+                    </Fragment>))}
                 </Fragment>
               }
             </div>

--- a/react/index.js
+++ b/react/index.js
@@ -91,15 +91,15 @@ class CategoryMenu extends Component {
       )
     }
     return (
-      <div className="vtex-category-menu bg-white dn flex-m justify-center">
-        <div className="vtex-category-menu__container flex flex-wrap justify-center items-end f6 overflow-hidden">
-          {showDepartmentsCategory && <CategoryItem noRedirect subcategoryLevels={1+showSubcategories} category={{
+      <div className="vtex-category-menu bg-base dn flex-m justify-center">
+        <div className="vtex-category-menu__container flex flex-wrap justify-center items-end t-body overflow-hidden">
+          {showDepartmentsCategory && <CategoryItem noRedirect subcategoryLevels={1 + showSubcategories} category={{
             children: categories,
             name: intl.formatMessage({ id: 'category-menu.departments.title' }),
           }} />}
           {departments.map(category => (
             <div key={category.id} className="flex items-center">
-              <CategoryItem category={category} subcategoryLevels={+showSubcategories}/>
+              <CategoryItem category={category} subcategoryLevels={+showSubcategories} />
             </div>
           ))}
         </div>

--- a/react/index.js
+++ b/react/index.js
@@ -92,7 +92,7 @@ class CategoryMenu extends Component {
     }
     return (
       <div className="vtex-category-menu bg-base dn flex-m justify-center">
-        <div className="vtex-category-menu__container flex flex-wrap justify-center items-end t-body overflow-hidden">
+        <div className="vtex-category-menu__container flex flex-wrap justify-center items-end t-action overflow-hidden">
           {showDepartmentsCategory && <CategoryItem noRedirect subcategoryLevels={1 + showSubcategories} category={{
             children: categories,
             name: intl.formatMessage({ id: 'category-menu.departments.title' }),


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Replace tachyons colors and typography classes with design tokens.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Make de style more customizable.

#### How should this be manually tested?
[Access this workspace](https://refactcatmenu--storecomponents.myvtex.com/)
#### Screenshots or example usage
*Before on mobile*
![captura de tela de 2018-10-31 17-09-03](https://user-images.githubusercontent.com/4912690/47815916-65bf3a80-dd30-11e8-852f-860d29ab5731.png)
*After on mobile*
![captura de tela de 2018-10-31 17-09-21](https://user-images.githubusercontent.com/4912690/47815941-77a0dd80-dd30-11e8-97b7-ca808ef4a2f1.png)

*Before on desktop*
![captura de tela de 2018-10-31 17-21-30](https://user-images.githubusercontent.com/4912690/47816334-a10e3900-dd31-11e8-93ac-b54a5d96c0a8.png)
*After on desktop*
![captura de tela de 2018-11-05 15-46-01](https://user-images.githubusercontent.com/4912690/48019306-e788dc80-e111-11e8-89f7-66dc62720870.png)

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

