### PR TITLE
Add prop to allow users to hide the departments category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add prop `showDepartmentsCategory` with default `true` to allow users to hide the departments category.
 
 ## [1.3.3] - 2018-10-30
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.4.0] - 2018-11-06
 ### Added
 - Add prop `showDepartmentsCategory` with default `true` to allow users to hide the departments category.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "category-menu",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "title": "Category Menu",
   "description": "Displays the categories for the store in a menu",
   "defaultLocale": "pt-BR",

--- a/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
@@ -9,6 +9,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
       "editor.category-menu.departments.items.id": "Department Id",
       "editor.category-menu.departments.items.title": "Department",
       "editor.category-menu.description": "A menu showing a list of the available categories on the store",
+      "editor.category-menu.show-departments-category.title": "Show the departments category",
       "editor.category-menu.show-gift-category.title": "Show the gifts category",
       "editor.category-menu.show-promotion-category.title": "Show the promotion category",
       "editor.category-menu.title": "Category menu",
@@ -131,6 +132,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
             "editor.category-menu.departments.items.id": "Department Id",
             "editor.category-menu.departments.items.title": "Department",
             "editor.category-menu.description": "A menu showing a list of the available categories on the store",
+            "editor.category-menu.show-departments-category.title": "Show the departments category",
             "editor.category-menu.show-gift-category.title": "Show the gifts category",
             "editor.category-menu.show-promotion-category.title": "Show the promotion category",
             "editor.category-menu.title": "Category menu",
@@ -141,6 +143,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
         }
       }
       mobileMode={false}
+      showDepartmentsCategory={true}
       showGiftCategory={false}
       showPromotionCategory={false}
     >

--- a/react/index.js
+++ b/react/index.js
@@ -29,6 +29,8 @@ class CategoryMenu extends Component {
     }),
     /** Set mobile mode */
     mobileMode: PropTypes.bool,
+    /** Whether to show the departments category or not */
+    showDepartmentsCategory: PropTypes.bool,
     /** Intl */
     intl: intlShape,
     /** Departments to be shown in the desktop mode. */
@@ -41,6 +43,7 @@ class CategoryMenu extends Component {
     showPromotionCategory: false,
     showGiftCategory: false,
     mobileMode: false,
+    showDepartmentsCategory: true,
     departments: [],
   }
 
@@ -63,6 +66,7 @@ class CategoryMenu extends Component {
       data: { categories = [] },
       intl,
       mobileMode,
+      showDepartmentsCategory
     } = this.props
     const departments = this.departmentsSelected.length && this.departmentsSelected ||
       categories.slice(0, MAX_NUMBER_OF_MENUS)
@@ -84,10 +88,10 @@ class CategoryMenu extends Component {
     return (
       <div className="vtex-category-menu bg-white dn flex-m justify-center">
         <div className="vtex-category-menu__container flex flex-wrap justify-center items-end f6 overflow-hidden">
-          <CategoryItem noRedirect category={{
+          {showDepartmentsCategory ? <CategoryItem noRedirect category={{
             children: categories,
             name: intl.formatMessage({ id: 'category-menu.departments.title' }),
-          }} />
+          }} /> : null}
           {departments.map(category => (
             <div key={category.id} className="flex items-center">
               <CategoryItem category={category} />
@@ -109,6 +113,10 @@ CategoryMenuWithIntl.schema = CategoryMenu.schema = {
     showPromotionCategory: {
       type: 'boolean',
       title: 'editor.category-menu.show-promotion-category.title',
+    },
+    showDepartmentsCategory: {
+      type: 'boolean',
+      title: 'editor.category-menu.show-departments-category.title',
     },
     showGiftCategory: {
       type: 'boolean',

--- a/react/index.js
+++ b/react/index.js
@@ -88,10 +88,10 @@ class CategoryMenu extends Component {
     return (
       <div className="vtex-category-menu bg-white dn flex-m justify-center">
         <div className="vtex-category-menu__container flex flex-wrap justify-center items-end f6 overflow-hidden">
-          {showDepartmentsCategory ? <CategoryItem noRedirect category={{
+          {showDepartmentsCategory && <CategoryItem noRedirect category={{
             children: categories,
             name: intl.formatMessage({ id: 'category-menu.departments.title' }),
-          }} /> : null}
+          }} />}
           {departments.map(category => (
             <div key={category.id} className="flex items-center">
               <CategoryItem category={category} />

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -2,6 +2,7 @@
   "editor.category-menu.title": "Category menu",
   "editor.category-menu.description": "A menu showing a list of the available categories on the store",
   "editor.category-menu.show-promotion-category.title": "Show the promotion category",
+  "editor.category-menu.show-departments-category.title": "Show the departments category",
   "editor.category-menu.show-gift-category.title": "Show the gifts category",
   "category-menu.departments.title": "Departments",
   "editor.category-menu.departments.items.title": "Department",

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -2,7 +2,7 @@
   "editor.category-menu.title": "Menú de categorías",
   "editor.category-menu.description": "Un menú que muestra una lista de categorías disponibles en la tienda",
   "editor.category-menu.show-promotion-category.title": "Mostrar la categoría de promoción",
-  "editor.category-menu.show-departments-category.title": "Mostrar la catergoría de departamentos",
+  "editor.category-menu.show-departments-category.title": "Mostrar la categoría de departamentos",
   "editor.category-menu.show-gift-category.title": "Mostrar la categoría de regalos",
   "category-menu.departments.title": "Departamentos",
   "editor.category-menu.departments.items.title": "Departamento",

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -2,6 +2,7 @@
   "editor.category-menu.title": "Menú de categorías",
   "editor.category-menu.description": "Un menú que muestra una lista de categorías disponibles en la tienda",
   "editor.category-menu.show-promotion-category.title": "Mostrar la categoría de promoción",
+  "editor.category-menu.show-departments-category.title": "Mostrar la catergoría de departamentos",
   "editor.category-menu.show-gift-category.title": "Mostrar la categoría de regalos",
   "category-menu.departments.title": "Departamentos",
   "editor.category-menu.departments.items.title": "Departamento",

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -2,6 +2,7 @@
   "editor.category-menu.title": "Menu de categorias",
   "editor.category-menu.description": "Um menu mostrando uma lista de categorias disponíveis na loja",
   "editor.category-menu.show-promotion-category.title": "Mostrar a categoria de promoção",
+  "editor.category-menu.show-departments-category.title": "Mostrar a catergoria de departamentos",
   "editor.category-menu.show-gift-category.title": "Mostrar a categoria de presentes",
   "category-menu.departments.title": "Departamentos",
   "editor.category-menu.departments.items.title": "Departamento",

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -2,7 +2,7 @@
   "editor.category-menu.title": "Menu de categorias",
   "editor.category-menu.description": "Um menu mostrando uma lista de categorias disponíveis na loja",
   "editor.category-menu.show-promotion-category.title": "Mostrar a categoria de promoção",
-  "editor.category-menu.show-departments-category.title": "Mostrar a catergoria de departamentos",
+  "editor.category-menu.show-departments-category.title": "Mostrar a categoria de departamentos",
   "editor.category-menu.show-gift-category.title": "Mostrar a categoria de presentes",
   "category-menu.departments.title": "Departamentos",
   "editor.category-menu.departments.items.title": "Departamento",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add prop `showDepartmentsCategory` with default `true` to allow users to hide the departments category.

#### What problem is this solving?
Stores with few categories still have the departments entry on the category header. This duplicates information and takes focus from the main categories (e.g. pizzas in PizzaHut)

#### How should this be manually tested?
Changes are linked on https://athos--delivery.myvtex.com/#

#### Screenshots or example usage
![kapture 2018-11-06 at 15 29 46](https://user-images.githubusercontent.com/7853668/48082270-53824800-e1d9-11e8-95ec-3022c0aea81d.gif)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

