### PR TITLE
Add prop that allow users to hide subcategories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add prop `showSubcategories` with default `true` to allow users to hide subcategories.
 
 ## [1.4.0] - 2018-11-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
 - Add prop `showSubcategories` with default `true` to allow users to hide subcategories.
 
 ## [1.4.0] - 2018-11-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.5.0] - 2018-11-07
 ### Added
 - Add prop `showSubcategories` with default `true` to allow users to hide subcategories.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "category-menu",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "title": "Category Menu",
   "description": "Displays the categories for the store in a menu",
   "defaultLocale": "pt-BR",

--- a/react/__tests__/__snapshots__/CategoryItem.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryItem.test.js.snap
@@ -18,28 +18,5 @@ exports[`CategoryItem component should match snapshot 1`] = `
   >
     CATEGORY
   </Link>
-  <div
-    className="absolute w-100 left-0"
-    style={
-      Object {
-        "display": "none",
-        "top": undefined,
-      }
-    }
-  >
-    <ItemContainer
-      categories={
-        Array [
-          Object {
-            "id": 2,
-            "name": "Sub-category",
-            "slug": "sub-category",
-          },
-        ]
-      }
-      onCloseMenu={[Function]}
-      parentSlug="category"
-    />
-  </div>
 </div>
 `;

--- a/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
@@ -186,10 +186,10 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   },
                 ],
                 "name": "Departments",
-                "showSubcategories": true,
               }
             }
             noRedirect={true}
+            subcategoryLevels={2}
           >
             <div
               className="vtex-category-menu__item flex justify-center items-center"
@@ -202,6 +202,123 @@ exports[`CategoryMenu component should match snapshot 1`] = `
               >
                 DEPARTMENTS
               </a>
+              <div
+                className="absolute w-100 left-0"
+                style={
+                  Object {
+                    "display": "none",
+                    "top": undefined,
+                  }
+                }
+              >
+                <ItemContainer
+                  categories={
+                    Array [
+                      Object {
+                        "children": Array [],
+                        "hasChildren": false,
+                        "href": "#1",
+                        "id": 1,
+                        "name": "Category 1",
+                        "slug": "category-1",
+                      },
+                      Object {
+                        "children": Array [],
+                        "hasChildren": false,
+                        "href": "#2",
+                        "id": 2,
+                        "name": "Category 2",
+                        "slug": "category-2",
+                      },
+                      Object {
+                        "children": Array [],
+                        "hasChildren": false,
+                        "href": "#3",
+                        "id": 3,
+                        "name": "Category 3",
+                        "slug": "category-3",
+                      },
+                    ]
+                  }
+                  onCloseMenu={[Function]}
+                  showSecondLevel={true}
+                >
+                  <div
+                    className="vtex-category-menu__item-container w-100 bg-white pb2 overflow-y-auto bw1 bb b--light-gray"
+                  >
+                    <div
+                      className="w-100 w-90-l w-80-xl center ph3-s ph7-m ph6-xl"
+                    >
+                      <div
+                        className="fl db pa2"
+                        key="1"
+                      >
+                        <Link
+                          className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                          onClick={[Function]}
+                          page="store/department"
+                          params={
+                            Object {
+                              "department": "category-1",
+                            }
+                          }
+                        >
+                          <a
+                            className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                            href="/category-1/s"
+                          >
+                            CATEGORY 1
+                          </a>
+                        </Link>
+                      </div>
+                      <div
+                        className="fl db pa2"
+                        key="2"
+                      >
+                        <Link
+                          className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                          onClick={[Function]}
+                          page="store/department"
+                          params={
+                            Object {
+                              "department": "category-2",
+                            }
+                          }
+                        >
+                          <a
+                            className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                            href="/category-2/s"
+                          >
+                            CATEGORY 2
+                          </a>
+                        </Link>
+                      </div>
+                      <div
+                        className="fl db pa2"
+                        key="3"
+                      >
+                        <Link
+                          className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                          onClick={[Function]}
+                          page="store/department"
+                          params={
+                            Object {
+                              "department": "category-3",
+                            }
+                          }
+                        >
+                          <a
+                            className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
+                            href="/category-3/s"
+                          >
+                            CATEGORY 3
+                          </a>
+                        </Link>
+                      </div>
+                    </div>
+                  </div>
+                </ItemContainer>
+              </div>
             </div>
           </CategoryItem>
           <div
@@ -219,7 +336,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   "slug": "category-1",
                 }
               }
-              showSubcategories={true}
+              subcategoryLevels={1}
             >
               <div
                 className="vtex-category-menu__item flex justify-center items-center"
@@ -261,7 +378,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   "slug": "category-2",
                 }
               }
-              showSubcategories={true}
+              subcategoryLevels={1}
             >
               <div
                 className="vtex-category-menu__item flex justify-center items-center"
@@ -303,7 +420,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   "slug": "category-3",
                 }
               }
-              showSubcategories={true}
+              subcategoryLevels={1}
             >
               <div
                 className="vtex-category-menu__item flex justify-center items-center"

--- a/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
@@ -12,6 +12,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
       "editor.category-menu.show-departments-category.title": "Show the departments category",
       "editor.category-menu.show-gift-category.title": "Show the gifts category",
       "editor.category-menu.show-promotion-category.title": "Show the promotion category",
+      "editor.category-menu.show-subcategories.title": "Show subcategories",
       "editor.category-menu.title": "Category menu",
     }
   }
@@ -135,6 +136,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
             "editor.category-menu.show-departments-category.title": "Show the departments category",
             "editor.category-menu.show-gift-category.title": "Show the gifts category",
             "editor.category-menu.show-promotion-category.title": "Show the promotion category",
+            "editor.category-menu.show-subcategories.title": "Show subcategories",
             "editor.category-menu.title": "Category menu",
           },
           "now": [Function],
@@ -146,6 +148,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
       showDepartmentsCategory={true}
       showGiftCategory={false}
       showPromotionCategory={false}
+      showSubcategories={true}
     >
       <div
         className="vtex-category-menu bg-white dn flex-m justify-center"
@@ -183,6 +186,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   },
                 ],
                 "name": "Departments",
+                "showSubcategories": true,
               }
             }
             noRedirect={true}
@@ -198,122 +202,6 @@ exports[`CategoryMenu component should match snapshot 1`] = `
               >
                 DEPARTMENTS
               </a>
-              <div
-                className="absolute w-100 left-0"
-                style={
-                  Object {
-                    "display": "none",
-                    "top": undefined,
-                  }
-                }
-              >
-                <ItemContainer
-                  categories={
-                    Array [
-                      Object {
-                        "children": Array [],
-                        "hasChildren": false,
-                        "href": "#1",
-                        "id": 1,
-                        "name": "Category 1",
-                        "slug": "category-1",
-                      },
-                      Object {
-                        "children": Array [],
-                        "hasChildren": false,
-                        "href": "#2",
-                        "id": 2,
-                        "name": "Category 2",
-                        "slug": "category-2",
-                      },
-                      Object {
-                        "children": Array [],
-                        "hasChildren": false,
-                        "href": "#3",
-                        "id": 3,
-                        "name": "Category 3",
-                        "slug": "category-3",
-                      },
-                    ]
-                  }
-                  onCloseMenu={[Function]}
-                >
-                  <div
-                    className="vtex-category-menu__item-container w-100 bg-white pb2 overflow-y-auto bw1 bb b--light-gray"
-                  >
-                    <div
-                      className="w-100 w-90-l w-80-xl center ph3-s ph7-m ph6-xl"
-                    >
-                      <div
-                        className="fl db pa2"
-                        key="1"
-                      >
-                        <Link
-                          className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
-                          onClick={[Function]}
-                          page="store/department"
-                          params={
-                            Object {
-                              "department": "category-1",
-                            }
-                          }
-                        >
-                          <a
-                            className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
-                            href="/category-1/s"
-                          >
-                            CATEGORY 1
-                          </a>
-                        </Link>
-                      </div>
-                      <div
-                        className="fl db pa2"
-                        key="2"
-                      >
-                        <Link
-                          className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
-                          onClick={[Function]}
-                          page="store/department"
-                          params={
-                            Object {
-                              "department": "category-2",
-                            }
-                          }
-                        >
-                          <a
-                            className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
-                            href="/category-2/s"
-                          >
-                            CATEGORY 2
-                          </a>
-                        </Link>
-                      </div>
-                      <div
-                        className="fl db pa2"
-                        key="3"
-                      >
-                        <Link
-                          className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
-                          onClick={[Function]}
-                          page="store/department"
-                          params={
-                            Object {
-                              "department": "category-3",
-                            }
-                          }
-                        >
-                          <a
-                            className="vtex-category-menu__link-level-2 db f6 fw4 no-underline pa4 outline-0 tl truncate c-on-base underline-hover"
-                            href="/category-3/s"
-                          >
-                            CATEGORY 3
-                          </a>
-                        </Link>
-                      </div>
-                    </div>
-                  </div>
-                </ItemContainer>
-              </div>
             </div>
           </CategoryItem>
           <div
@@ -331,6 +219,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   "slug": "category-1",
                 }
               }
+              showSubcategories={true}
             >
               <div
                 className="vtex-category-menu__item flex justify-center items-center"
@@ -372,6 +261,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   "slug": "category-2",
                 }
               }
+              showSubcategories={true}
             >
               <div
                 className="vtex-category-menu__item flex justify-center items-center"
@@ -413,6 +303,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   "slug": "category-3",
                 }
               }
+              showSubcategories={true}
             >
               <div
                 className="vtex-category-menu__item flex justify-center items-center"

--- a/react/components/CategoryItem.js
+++ b/react/components/CategoryItem.js
@@ -20,12 +20,14 @@ export default class CategoryItem extends Component {
     category: categoryItemShape.isRequired,
     /** Set use of Link component */
     noRedirect: PropTypes.bool,
+    /** Whether to show subcategories or not */
+    showSubcategories: PropTypes.bool,
   }
 
   handleCloseMenu = () => (this.setState({ isHover: false }))
 
   render() {
-    const { category } = this.props
+    const { category, showSubcategories } = this.props
     const { isHover } = this.state
 
     const containerStyle = {
@@ -62,7 +64,7 @@ export default class CategoryItem extends Component {
             {category.name.toUpperCase()}
           </Link>
         )}
-        {category.children.length > 0 && (
+        {showSubcategories && category.children.length > 0 && (
           <div className="absolute w-100 left-0" style={containerStyle}>
             <ItemContainer
               categories={category.children}

--- a/react/components/CategoryItem.js
+++ b/react/components/CategoryItem.js
@@ -21,13 +21,13 @@ export default class CategoryItem extends Component {
     /** Set use of Link component */
     noRedirect: PropTypes.bool,
     /** Whether to show subcategories or not */
-    showSubcategories: PropTypes.bool,
+    subcategoryLevels: PropTypes.oneOf([0, 1, 2]),
   }
 
   handleCloseMenu = () => (this.setState({ isHover: false }))
 
   render() {
-    const { category, showSubcategories } = this.props
+    const { category, subcategoryLevels } = this.props
     const { isHover } = this.state
 
     const containerStyle = {
@@ -64,12 +64,13 @@ export default class CategoryItem extends Component {
             {category.name.toUpperCase()}
           </Link>
         )}
-        {showSubcategories && category.children.length > 0 && (
+        {subcategoryLevels > 0 && category.children.length > 0 && (
           <div className="absolute w-100 left-0" style={containerStyle}>
             <ItemContainer
               categories={category.children}
               parentSlug={category.slug}
               onCloseMenu={this.handleCloseMenu}
+              showSecondLevel={subcategoryLevels === 2}
             />
           </div>
         )}

--- a/react/components/ItemContainer.js
+++ b/react/components/ItemContainer.js
@@ -16,6 +16,8 @@ export default class ItemContainer extends Component {
     parentSlug: PropTypes.string,
     /** Close menu callback */
     onCloseMenu: PropTypes.func.isRequired,
+    /** Whether to show second level links or not */
+    showSecondLevel: PropTypes.bool,
   }
 
   renderLinkFirstLevel(parentSlug, item) {
@@ -62,7 +64,7 @@ export default class ItemContainer extends Component {
               {this.renderLinkFirstLevel(this.props.parentSlug, category)}
               {category.children && category.children.length > 0 && (
                 <Fragment>
-                  {category.children.map((subCategory) => (
+                  {this.props.showSecondLevel && category.children.map((subCategory) => (
                     <Fragment key={subCategory.id}>
                       <span className="flex bt w-90 b--light-gray center"></span>
                       {this.renderLinkSecondLevel(this.props.parentSlug, category, subCategory)}

--- a/react/components/SideBar.js
+++ b/react/components/SideBar.js
@@ -18,6 +18,8 @@ export default class SideBar extends Component {
     onClose: PropTypes.func,
     /** Sidebar's visibility. */
     visible: PropTypes.bool,
+    /** Whether to show subcategories or not */
+    showSubcategories: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -51,7 +53,7 @@ export default class SideBar extends Component {
   }
 
   render() {
-    const { visible } = this.props
+    const { visible, onClose, showSubcategories } = this.props
 
     const scrimClasses = classNames('vtex-menu-sidebar__scrim fixed dim bg-near-black top-0 z-1 w-100 vh-100 o-40', {
       dn: !visible,
@@ -68,7 +70,7 @@ export default class SideBar extends Component {
           <div className="vtex-menu-sidebar w-100 bg-white vh-100">
             <div
               className="vtex-menu-sidebar__header flex justify-between items-center pa4 pl6 shadow-4 pointer h3"
-              onClick={() => this.props.onClose()}
+              onClick={onClose}
             >
               <span className="f4 fw5 dark-gray">{this.props.title}</span>
               <IconCaretLeft size={13} color="#585959" />
@@ -80,7 +82,8 @@ export default class SideBar extends Component {
                   <SideBarItem
                     item={department}
                     linkValues={[department.slug]}
-                    onClose={this.props.onClose}
+                    onClose={onClose}
+                    showSubcategories={showSubcategories}
                   />
                 </Fragment>
               ))}

--- a/react/components/SideBarItem.js
+++ b/react/components/SideBarItem.js
@@ -18,6 +18,8 @@ class SideBarItem extends Component {
     }),
     /** Tree level. */
     treeLevel: PropTypes.number,
+    /** Whether to show subcategories or not */
+    showSubcategories: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -50,8 +52,8 @@ class SideBarItem extends Component {
   }
 
   render() {
-    const { item, linkValues, runtime, onClose, treeLevel } = this.props
-    const hasChildren = item.children && item.children.length > 0
+    const { item, linkValues, runtime, onClose, treeLevel, showSubcategories } = this.props
+    const hasChildren = showSubcategories && item.children && item.children.length > 0
     const sideBarItemClasses = classNames(
       'vtex-menu-sidebar__item', {
         'bg-light-silver mid-gray fw3': treeLevel > 1,

--- a/react/components/SideBarItem.js
+++ b/react/components/SideBarItem.js
@@ -31,8 +31,8 @@ class SideBarItem extends Component {
   }
 
   handleItemClick = () => {
-    const { item: { children }, runtime, onClose, linkValues } = this.props
-    if (children && children.length) {
+    const { item: { children }, runtime, onClose, linkValues, showSubcategories } = this.props
+    if (showSubcategories && children && children.length) {
       this.setState({ open: !this.state.open })
     } else {
       const [department, category, subcategory] = linkValues

--- a/react/index.js
+++ b/react/index.js
@@ -93,14 +93,13 @@ class CategoryMenu extends Component {
     return (
       <div className="vtex-category-menu bg-white dn flex-m justify-center">
         <div className="vtex-category-menu__container flex flex-wrap justify-center items-end f6 overflow-hidden">
-          {showDepartmentsCategory && <CategoryItem noRedirect category={{
+          {showDepartmentsCategory && <CategoryItem noRedirect subcategoryLevels={1+showSubcategories} category={{
             children: categories,
             name: intl.formatMessage({ id: 'category-menu.departments.title' }),
-            showSubcategories: true,
           }} />}
           {departments.map(category => (
             <div key={category.id} className="flex items-center">
-              <CategoryItem category={category} showSubcategories={showSubcategories}/>
+              <CategoryItem category={category} subcategoryLevels={+showSubcategories}/>
             </div>
           ))}
         </div>

--- a/react/index.js
+++ b/react/index.js
@@ -31,6 +31,8 @@ class CategoryMenu extends Component {
     mobileMode: PropTypes.bool,
     /** Whether to show the departments category or not */
     showDepartmentsCategory: PropTypes.bool,
+    /** Whether to show subcategories or not */
+    showSubcategories: PropTypes.bool,
     /** Intl */
     intl: intlShape,
     /** Departments to be shown in the desktop mode. */
@@ -44,6 +46,7 @@ class CategoryMenu extends Component {
     showGiftCategory: false,
     mobileMode: false,
     showDepartmentsCategory: true,
+    showSubcategories: true,
     departments: [],
   }
 
@@ -66,7 +69,8 @@ class CategoryMenu extends Component {
       data: { categories = [] },
       intl,
       mobileMode,
-      showDepartmentsCategory
+      showDepartmentsCategory,
+      showSubcategories
     } = this.props
     const departments = this.departmentsSelected.length && this.departmentsSelected ||
       categories.slice(0, MAX_NUMBER_OF_MENUS)
@@ -78,7 +82,8 @@ class CategoryMenu extends Component {
             visible={this.state.sideBarVisible}
             title={intl.formatMessage({ id: 'category-menu.departments.title' })}
             departments={categories}
-            onClose={this.handleSidebarToggle} />
+            onClose={this.handleSidebarToggle}
+            showSubcategories={showSubcategories} />
           <div className="flex pa4 pointer" onClick={this.handleSidebarToggle}>
             <HamburguerIcon />
           </div>
@@ -91,10 +96,11 @@ class CategoryMenu extends Component {
           {showDepartmentsCategory && <CategoryItem noRedirect category={{
             children: categories,
             name: intl.formatMessage({ id: 'category-menu.departments.title' }),
+            showSubcategories: true,
           }} />}
           {departments.map(category => (
             <div key={category.id} className="flex items-center">
-              <CategoryItem category={category} />
+              <CategoryItem category={category} showSubcategories={showSubcategories}/>
             </div>
           ))}
         </div>
@@ -117,6 +123,10 @@ CategoryMenuWithIntl.schema = CategoryMenu.schema = {
     showDepartmentsCategory: {
       type: 'boolean',
       title: 'editor.category-menu.show-departments-category.title',
+    },
+    showSubcategories: {
+      type: 'boolean',
+      title: 'editor.category-menu.show-subcategories.title',
     },
     showGiftCategory: {
       type: 'boolean',

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -3,6 +3,7 @@
   "editor.category-menu.description": "A menu showing a list of the available categories on the store",
   "editor.category-menu.show-promotion-category.title": "Show the promotion category",
   "editor.category-menu.show-departments-category.title": "Show the departments category",
+  "editor.category-menu.show-subcategories.title": "Show subcategories",
   "editor.category-menu.show-gift-category.title": "Show the gifts category",
   "category-menu.departments.title": "Departments",
   "editor.category-menu.departments.items.title": "Department",

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -3,6 +3,7 @@
   "editor.category-menu.description": "Un menú que muestra una lista de categorías disponibles en la tienda",
   "editor.category-menu.show-promotion-category.title": "Mostrar la categoría de promoción",
   "editor.category-menu.show-departments-category.title": "Mostrar la categoría de departamentos",
+  "editor.category-menu.show-subcategories.title": "Mostrar subcategorías",
   "editor.category-menu.show-gift-category.title": "Mostrar la categoría de regalos",
   "category-menu.departments.title": "Departamentos",
   "editor.category-menu.departments.items.title": "Departamento",

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -3,6 +3,7 @@
   "editor.category-menu.description": "Um menu mostrando uma lista de categorias disponíveis na loja",
   "editor.category-menu.show-promotion-category.title": "Mostrar a categoria de promoção",
   "editor.category-menu.show-departments-category.title": "Mostrar a categoria de departamentos",
+  "editor.category-menu.show-subcategories.title": "Mostrar subcategorias",
   "editor.category-menu.show-gift-category.title": "Mostrar a categoria de presentes",
   "category-menu.departments.title": "Departamentos",
   "editor.category-menu.departments.items.title": "Departamento",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add prop `showSubcategories` with default `true` to allow users to hide subcategories.

#### What problem is this solving?
Some kinds of store (e.g. pizzahut) don't need subcategories to be displayed at the `category-menu`, since they have a limited number of products and a lean design is best.

#### How should this be manually tested?
Changes are live on https://athos--delivery.myvtex.com/, feel free to use the admin to change the props and check de differences.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

