### PR TITLE
Fix subcategories is not showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fix not showing's subcategories.
+- Fix subcategories that were not being displayed.
 
 ## [2.2.0] - 2018-12-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.2.1] - 2018-12-18
 ### Fixed
 - Fix subcategories that were not being displayed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fix subcategories are not showing.
+- Fix not showing's subcategories.
 
 ## [2.2.0] - 2018-12-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix subcategories are not showing.
 
 ## [2.2.0] - 2018-12-18
 ### Added
 - Support to CSS Modules.
 
 ## [2.1.0] - 2018-11-30
-
 ### Changed
 - Add new icons and improve layout
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "category-menu",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "title": "Category Menu",
   "description": "Displays the categories for the store in a menu",
   "defaultLocale": "pt-BR",

--- a/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
@@ -339,7 +339,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   "slug": "category-1",
                 }
               }
-              subcategoryLevels={1}
+              subcategoryLevels={2}
             >
               <div
                 className="undefined flex justify-center items-center"
@@ -381,7 +381,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   "slug": "category-2",
                 }
               }
-              subcategoryLevels={1}
+              subcategoryLevels={2}
             >
               <div
                 className="undefined flex justify-center items-center"
@@ -423,7 +423,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                   "slug": "category-3",
                 }
               }
-              subcategoryLevels={1}
+              subcategoryLevels={2}
             >
               <div
                 className="undefined flex justify-center items-center"

--- a/react/components/SideBarItem.js
+++ b/react/components/SideBarItem.js
@@ -117,6 +117,7 @@ class SideBarItem extends Component {
                   <span className="flex w-90 center"></span>
                   <SideBarItem
                     runtime={runtime}
+                    showSubcategories={showSubcategories}
                     item={child}
                     linkValues={[...linkValues, child.slug]}
                     onClose={onClose}

--- a/react/index.js
+++ b/react/index.js
@@ -75,6 +75,8 @@ class CategoryMenu extends Component {
     const departments = this.departmentsSelected.length && this.departmentsSelected ||
       categories.slice(0, MAX_NUMBER_OF_MENUS)
 
+    console.log(1 + showSubcategories)
+
     if (mobileMode) {
       return (
         <div className={`${categoryMenu.container} ${categoryMenu.mobile}`}>
@@ -99,7 +101,7 @@ class CategoryMenu extends Component {
           }} />}
           {departments.map(category => (
             <div key={category.id} className="flex items-center">
-              <CategoryItem category={category} subcategoryLevels={+showSubcategories} />
+              <CategoryItem category={category} subcategoryLevels={1 + showSubcategories} />
             </div>
           ))}
         </div>

--- a/react/index.js
+++ b/react/index.js
@@ -12,6 +12,7 @@ import getCategories from './queries/categoriesQuery.gql'
 import categoryMenu from './categoryMenu.css'
 
 const MAX_NUMBER_OF_MENUS = 6
+const DEFAULT_SUBCATEGORIES_LEVELS = 1
 
 /**
  * Component that represents the menu containing the categories of the store
@@ -93,13 +94,13 @@ class CategoryMenu extends Component {
     return (
       <div className={`${categoryMenu.container} bg-base dn flex-m justify-center`}>
         <div className="flex flex-wrap justify-center items-end t-action overflow-hidden">
-          {showDepartmentsCategory && <CategoryItem noRedirect subcategoryLevels={1 + showSubcategories} category={{
+          {showDepartmentsCategory && <CategoryItem noRedirect subcategoryLevels={DEFAULT_SUBCATEGORIES_LEVELS + showSubcategories} category={{
             children: categories,
             name: intl.formatMessage({ id: 'category-menu.departments.title' }),
           }} />}
           {departments.map(category => (
             <div key={category.id} className="flex items-center">
-              <CategoryItem category={category} subcategoryLevels={1 + showSubcategories} />
+              <CategoryItem category={category} subcategoryLevels={DEFAULT_SUBCATEGORIES_LEVELS + showSubcategories} />
             </div>
           ))}
         </div>

--- a/react/index.js
+++ b/react/index.js
@@ -75,8 +75,6 @@ class CategoryMenu extends Component {
     const departments = this.departmentsSelected.length && this.departmentsSelected ||
       categories.slice(0, MAX_NUMBER_OF_MENUS)
 
-    console.log(1 + showSubcategories)
-
     if (mobileMode) {
       return (
         <div className={`${categoryMenu.container} ${categoryMenu.mobile}`}>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix subcategories is not showing.

#### What problem is this solving?

Subcategories is not showing.

#### How should this be manually tested?

[Access this workspace](https://orderby--storecomponents.myvtex.com/)

#### Screenshots or example usage

![orderby--storecomponents myvtex com_ pixel 2 xl](https://user-images.githubusercontent.com/10901554/49956765-25d1a280-feed-11e8-9ae3-e750eb61a3a7.png)
![orderby--storecomponents myvtex com_](https://user-images.githubusercontent.com/10901554/49956771-28cc9300-feed-11e8-9529-5eba458dcbe3.png)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

