### PR TITLE
Fix scroll not appearing in mobile mode when it overflow its container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Scroll is not appearing in the mobile mode when the `CategoryMenu` overflow its container.
 
 ## [2.3.0] - 2018-12-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.1] - 2018-12-21
 ### Fixed
 - Scroll is not appearing in the mobile mode when the `CategoryMenu` overflow its container.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "category-menu",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "title": "Category Menu",
   "description": "Displays the categories for the store in a menu",
   "defaultLocale": "pt-BR",

--- a/react/components/SideBar.js
+++ b/react/components/SideBar.js
@@ -69,7 +69,7 @@ export default class SideBar extends Component {
           type="drawerRight"
           className="fixed w-80 left--1 top-0 z-max"
         >
-          <div className={`${categoryMenu.sidebar} w-100 bg-base z-max vh-100 shadow-5 `}>
+          <div className={`${categoryMenu.sidebar} w-100 bg-base z-max vh-100 shadow-5 overflow-scroll`}>
             <div
               className={`${categoryMenu.sidebarHeader} flex justify-between items-center pa5 pointer`}
               onClick={onClose}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix scroll not appearing in mobile mode when it overflow its container.

#### What problem is this solving?
![image](https://user-images.githubusercontent.com/12852518/50345053-62645600-050c-11e9-99cc-abd8da279175.png)

#### How should this be manually tested?
[Click here to access the workspace.](https://waza--storecomponents.myvtex.com/)

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

