### PR TITLE
Fix the sidebar that was not showing its whole content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix `SideBar` not showing the hole content.
 
 ## [2.3.2] - 2018-12-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.3] - 2018-12-21
 ### Fixed
 - Fix `SideBar` not showing the whole content when scrolling.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fix `SideBar` not showing the hole content.
+- Fix `SideBar` not showing the whole content when scrolling.
 
 ## [2.3.2] - 2018-12-21
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "category-menu",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "title": "Category Menu",
   "description": "Displays the categories for the store in a menu",
   "defaultLocale": "pt-BR",

--- a/react/components/SideBar.js
+++ b/react/components/SideBar.js
@@ -60,7 +60,7 @@ export default class SideBar extends Component {
     const scrimClasses = classNames(`${categoryMenu.sidebarScrim} fixed dim bg-base--inverted top-0 z-1 vw-100 vh-100 o-40`, {
       dn: !visible,
     })
-
+    
     return (
       <Fragment>
         <div className={scrimClasses} onClick={this.props.onClose} />
@@ -76,7 +76,7 @@ export default class SideBar extends Component {
             >
               <IconClose size={24} color="#585959" />
             </div>
-            <div className={`${categoryMenu.sidebarContent} overflow-y-auto`}>
+            <div className={`${categoryMenu.sidebarContent} pb7`}>
               {this.props.departments.map(department => (
                 <Fragment key={department.id}>
                   <span className="flex w-90 center"></span>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the sidebar that was not showing its whole content.
![captura de tela de 2018-12-21 17-28-51](https://user-images.githubusercontent.com/12852518/50362334-16360780-0546-11e9-917b-3eee10a753d4.png)

#### How should this be manually tested?
[Click here to access the workspace.](https://waza2--storecomponents.myvtex.com/)

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

