### PR TITLE
Show default props correctly on pages-editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Show default props correctly on pages-editor.
 
 ## [2.3.3] - 2018-12-21
 ### Fixed
@@ -21,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.3.0] - 2018-12-19
 ### Added
-- Support to messages builder. 
+- Support to messages builder.
 
 ## [2.2.2] - 2018-12-19
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.4] - 2019-01-08
 ### Fixed
 - Show default props correctly on pages-editor.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "category-menu",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "title": "Category Menu",
   "description": "Displays the categories for the store in a menu",
   "defaultLocale": "pt-BR",

--- a/react/index.js
+++ b/react/index.js
@@ -119,22 +119,22 @@ CategoryMenuWithIntl.schema = CategoryMenu.schema = {
     showPromotionCategory: {
       type: 'boolean',
       title: 'editor.category-menu.show-promotion-category.title',
-      default: false,
+      default: CategoryMenu.defaultProps.showPromotionCategory,
     },
     showDepartmentsCategory: {
       type: 'boolean',
       title: 'editor.category-menu.show-departments-category.title',
-      default: true,
+      default: CategoryMenu.defaultProps.showDepartmentsCategory,
     },
     showSubcategories: {
       type: 'boolean',
       title: 'editor.category-menu.show-subcategories.title',
-      default: true,
+      default: CategoryMenu.defaultProps.showSubcategories,
     },
     showGiftCategory: {
       type: 'boolean',
       title: 'editor.category-menu.show-gift-category.title',
-      default: false,
+      default: CategoryMenu.defaultProps.showGiftCategory,
     },
     departments: {
       title: 'category-menu.departments.title',

--- a/react/index.js
+++ b/react/index.js
@@ -119,18 +119,22 @@ CategoryMenuWithIntl.schema = CategoryMenu.schema = {
     showPromotionCategory: {
       type: 'boolean',
       title: 'editor.category-menu.show-promotion-category.title',
+      default: false,
     },
     showDepartmentsCategory: {
       type: 'boolean',
       title: 'editor.category-menu.show-departments-category.title',
+      default: true,
     },
     showSubcategories: {
       type: 'boolean',
       title: 'editor.category-menu.show-subcategories.title',
+      default: true,
     },
     showGiftCategory: {
       type: 'boolean',
       title: 'editor.category-menu.show-gift-category.title',
+      default: false,
     },
     departments: {
       title: 'category-menu.departments.title',


### PR DESCRIPTION
#### What is the purpose of this pull request?
The pages editor is not showing the same config default of the component.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

