### PR TITLE
Fix/incorrect align category items mobile view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed incorrect align rendering category items with tree level above 2.
 
 ## [2.4.3] - 2019-01-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.4.4] - 2019-01-17
 ### Fixed
 - Fixed incorrect align rendering category items with tree level above 2.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "category-menu",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "title": "Category Menu",
   "description": "Displays the categories for the store in a menu",
   "defaultLocale": "pt-BR",

--- a/react/components/SideBarItem.js
+++ b/react/components/SideBarItem.js
@@ -79,7 +79,6 @@ class SideBarItem extends Component {
       }
     )
     const sideBarItemTitleClasses = classNames('', {
-      'ml5': treeLevel === 3,
       't-heading-4 lh-solid': treeLevel === 1
     })
     return (


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove 'm15' class when treeLevel is equals to 3.

#### What problem is this solving?
It solves the wrong alignment in deeper categories. It occurs when the user is in mobile view.

#### How should this be manually tested?
In mobile view, open the category menu, open "Decoration" and then "Smartphones". You should see "Accessories" and "Battery" as children from "See All" when actually they are in the same hierarchy.

#### Screenshots or example usage
Before
![](https://user-images.githubusercontent.com/9946330/51186938-86237d80-18b9-11e9-9afd-7cf6feedf433.png)

After
![](https://user-images.githubusercontent.com/9946330/51186990-a18e8880-18b9-11e9-9de7-3d472a3e6f6b.png)

[Workspace Link](https://categorymenutreelevel--storecomponents.myvtex.com/)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

