### PR TITLE
 Add menu disposition types on storefront

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Customization of the menu disposition (left, center, right).
 
 ## [2.9.0] - 2019-02-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.10.0] - 2019-02-07
 ### Added
 - Customization of the menu disposition (left, center, right).
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "category-menu",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "title": "Category Menu",
   "description": "Displays the categories for the store in a menu",
   "defaultLocale": "pt-BR",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -8,5 +8,9 @@
   "category-menu.departments.title": "Departments",
   "editor.category-menu.departments.items.title": "Department",
   "editor.category-menu.departments.items.id": "Department Id",
-  "category-menu.all-category.title": "See All"
+  "category-menu.all-category.title": "See All",
+  "editor.category-menu.disposition-type.title": "Menu disposition",
+  "editor.category-menu.disposition-type.center": "Middle",
+  "editor.category-menu.disposition-type.left": "Left",
+  "editor.category-menu.disposition-type.right": "Right"
 }

--- a/messages/es-AR.json
+++ b/messages/es-AR.json
@@ -8,5 +8,9 @@
   "category-menu.departments.title": "Departamentos",
   "editor.category-menu.departments.items.title": "Departamento",
   "editor.category-menu.departments.items.id": "Id del Departamento",
-  "category-menu.all-category.title": "Ver Todos"
+  "category-menu.all-category.title": "Ver Todos",
+  "editor.category-menu.disposition-type.title": "Disposición del menú",
+  "editor.category-menu.disposition-type.center": "Centro",
+  "editor.category-menu.disposition-type.left": "Izquierda",
+  "editor.category-menu.disposition-type.right": "Derecho"
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -8,5 +8,10 @@
   "category-menu.departments.title": "Departamentos",
   "editor.category-menu.departments.items.title": "Departamento",
   "editor.category-menu.departments.items.id": "Id do Departamento",
-  "category-menu.all-category.title": "Ver Todos"
+  "category-menu.all-category.title": "Ver Todos",
+  "editor.category-menu.disposition-type.title": "Disposição do menu",
+  "editor.category-menu.disposition-type.center": "Centro",
+  "editor.category-menu.disposition-type.left": "Esquerda",
+  "editor.category-menu.disposition-type.right": "Direita"
+  
 }

--- a/react/components/CategoryItem.js
+++ b/react/components/CategoryItem.js
@@ -6,7 +6,7 @@ import { categoryItemShape } from '../propTypes'
 import ItemContainer from './ItemContainer'
 import classNames from 'classnames'
 import categoryMenu from '../categoryMenu.css'
-import categoryMenuDisposition from '../utils/categoryMenuDisposition' 
+import categoryMenuDisposition, { getMenuDispositionValues } from '../utils/categoryMenuDisposition'
 
 /**
  * Component that represents a single category displayed in the menu, also displays
@@ -24,12 +24,16 @@ export default class CategoryItem extends Component {
     noRedirect: PropTypes.bool,
     /** Number of subcategory levels */
     subcategoryLevels: PropTypes.oneOf([0, 1, 2]),
+    /** Defines the disposition of the category menu */
+    menuDisposition: PropTypes.oneOf(getMenuDispositionValues()),
+    /** Menu category selection */
+    isCategorySelected: PropTypes.bool,
   }
 
   handleCloseMenu = () => (this.setState({ isOnHover: false }))
 
   renderCategory() {
-    const { category: { name, slug }, noRedirect, isCategorySelected, menuDisposition} = this.props
+    const { category: { name, slug }, noRedirect, isCategorySelected, menuDisposition } = this.props
     const { isOnHover } = this.state
 
     const categoryClasses = classNames(

--- a/react/components/CategoryItem.js
+++ b/react/components/CategoryItem.js
@@ -6,6 +6,7 @@ import { categoryItemShape } from '../propTypes'
 import ItemContainer from './ItemContainer'
 import classNames from 'classnames'
 import categoryMenu from '../categoryMenu.css'
+import categoryMenuDisposition from '../utils/categoryMenuDisposition' 
 
 /**
  * Component that represents a single category displayed in the menu, also displays
@@ -28,13 +29,16 @@ export default class CategoryItem extends Component {
   handleCloseMenu = () => (this.setState({ isOnHover: false }))
 
   renderCategory() {
-    const { category: { name, slug }, noRedirect, isCategorySelected } = this.props
+    const { category: { name, slug }, noRedirect, isCategorySelected, menuDisposition} = this.props
     const { isOnHover } = this.state
 
     const categoryClasses = classNames(
-      'w-100 pv5 mh6 no-underline t-small outline-0 db tc ttu link truncate bb bw1 c-muted-1', {
+      'w-100 pv5 no-underline t-small outline-0 db tc ttu link truncate bb bw1 c-muted-1', {
         'b--transparent': !isOnHover && !isCategorySelected,
-        'b--action-primary pointer': isOnHover || isCategorySelected
+        'b--action-primary pointer': isOnHover || isCategorySelected,
+        'mr8': menuDisposition === categoryMenuDisposition.DISPLAY_LEFT.value,
+        'ml8': menuDisposition === categoryMenuDisposition.DISPLAY_RIGHT.value,
+        'mh6': menuDisposition === categoryMenuDisposition.DISPLAY_CENTER.value,
       }
     )
 
@@ -55,7 +59,7 @@ export default class CategoryItem extends Component {
   }
 
   renderChildren() {
-    const { category, subcategoryLevels } = this.props
+    const { category, subcategoryLevels, menuDisposition } = this.props
     const { isOnHover } = this.state
 
     const containerStyle = {
@@ -65,6 +69,7 @@ export default class CategoryItem extends Component {
 
     return subcategoryLevels > 0 && category.children.length > 0 && (
       <ItemContainer
+        menuDisposition={menuDisposition}
         containerStyle={containerStyle}
         categories={category.children}
         parentSlug={category.slug}

--- a/react/components/ItemContainer.js
+++ b/react/components/ItemContainer.js
@@ -6,7 +6,7 @@ import { Container } from 'vtex.store-components'
 
 import PropTypes from 'prop-types'
 import categoryMenu from '../categoryMenu.css'
-import categoryMenuDisposition from '../utils/categoryMenuDisposition' 
+import categoryMenuDisposition, { getMenuDispositionValues } from '../utils/categoryMenuDisposition'
 
 /**
  * Component responsible dor rendering an array of categories and its respective subcategories
@@ -21,7 +21,8 @@ export default class ItemContainer extends Component {
     onCloseMenu: PropTypes.func.isRequired,
     /** Whether to show second level links or not */
     showSecondLevel: PropTypes.bool,
-
+    /** Defines the disposition of the category menu */
+    menuDisposition: PropTypes.oneOf(getMenuDispositionValues()),
     /** Custom styles to item container */
     containerStyle: PropTypes.object,
   }
@@ -93,7 +94,7 @@ export default class ItemContainer extends Component {
     const columnItemClasses = classNames({
       'pl0 pr7': menuDisposition === categoryMenuDisposition.DISPLAY_LEFT.value,
       'pr0 pl7': menuDisposition === categoryMenuDisposition.DISPLAY_RIGHT.value,
-    }) 
+    })
 
     return (
       <div className={`${categoryMenu.itemContainer} absolute w-100 left-0 bg-base pb2 bw1 bb b--muted-3`} style={containerStyle}>

--- a/react/components/ItemContainer.js
+++ b/react/components/ItemContainer.js
@@ -1,9 +1,12 @@
 import React, { Component } from 'react'
 import { Link } from 'vtex.render-runtime'
 import { categoryPropType } from '../propTypes'
+import classNames from 'classnames'
+import { Container } from 'vtex.store-components'
 
 import PropTypes from 'prop-types'
 import categoryMenu from '../categoryMenu.css'
+import categoryMenuDisposition from '../utils/categoryMenuDisposition' 
 
 /**
  * Component responsible dor rendering an array of categories and its respective subcategories
@@ -79,19 +82,33 @@ export default class ItemContainer extends Component {
   }
 
   render() {
-    const { containerStyle, categories, parentSlug } = this.props
+    const { containerStyle, categories, parentSlug, menuDisposition } = this.props
+
+    const containerClasses = classNames('w-100 flex flex-wrap pa0 list mw9', {
+      'justify-start': menuDisposition === categoryMenuDisposition.DISPLAY_LEFT.value,
+      'justify-end': menuDisposition === categoryMenuDisposition.DISPLAY_RIGHT.value,
+      'justify-center': menuDisposition === categoryMenuDisposition.DISPLAY_CENTER.value,
+    })
+
+    const columnItemClasses = classNames({
+      'pl0 pr7': menuDisposition === categoryMenuDisposition.DISPLAY_LEFT.value,
+      'pr0 pl7': menuDisposition === categoryMenuDisposition.DISPLAY_RIGHT.value,
+    }) 
+
     return (
       <div className={`${categoryMenu.itemContainer} absolute w-100 left-0 bg-base pb2 bw1 bb b--muted-3`} style={containerStyle}>
-        <ul className="w-100 w-90-l w-80-xl center flex flex-wrap pa0 list">
-          {categories.map(category => (
-            <li key={category.id} className="dib pa2">
-              <ul>
-                {this.renderLinkFirstLevel(parentSlug, category)}
-                {this.renderChildren(category)}
-              </ul>
-            </li>
-          ))}
-        </ul>
+        <Container className="justify-center w-100 flex">
+          <ul className={containerClasses}>
+            {categories.map(category => (
+              <li key={category.id} className="dib pa2">
+                <ul className={columnItemClasses}>
+                  {this.renderLinkFirstLevel(parentSlug, category)}
+                  {this.renderChildren(category)}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        </Container>
       </div>
     )
   }

--- a/react/index.js
+++ b/react/index.js
@@ -3,8 +3,12 @@ import React, { Component, Fragment } from 'react'
 import { graphql } from 'react-apollo'
 import { injectIntl, intlShape } from 'react-intl'
 import { IconMenu } from 'vtex.dreamstore-icons'
+<<<<<<< HEAD
 import { withRuntimeContext } from 'vtex.render-runtime'
 import { compose } from 'ramda'
+=======
+import classNames from 'classnames'
+>>>>>>> Add menu disposition types on storefront
 
 import CategoryItem from './components/CategoryItem'
 import SideBar from './components/SideBar'
@@ -12,6 +16,10 @@ import { categoryPropType } from './propTypes'
 import getCategories from './queries/categoriesQuery.gql'
 
 import categoryMenu from './categoryMenu.css'
+import categoryMenuDisposition, {
+  getMenuDispositionNames,
+  getMenuDispositionValues,
+} from './utils/categoryMenuDisposition' 
 
 const DEFAULT_SUBCATEGORIES_LEVELS = 1
 
@@ -35,6 +43,8 @@ class CategoryMenu extends Component {
     showAllDepartments: PropTypes.bool,
     /** Whether to show subcategories or not */
     showSubcategories: PropTypes.bool,
+    /** Defines the disposition of the category menu */
+    menuDisposition: PropTypes.oneOf(getMenuDispositionValues()),
     /** Intl */
     intl: intlShape,
     /** Departments to be shown in the desktop mode. */
@@ -49,6 +59,7 @@ class CategoryMenu extends Component {
     mobileMode: false,
     showAllDepartments: true,
     showSubcategories: true,
+    menuDisposition: categoryMenuDisposition.DISPLAY_LEFT.value,
     departments: [],
   }
 
@@ -73,7 +84,7 @@ class CategoryMenu extends Component {
       intl,
       showSubcategories,
     } = this.props
-    const { sideBarVisible } = this.state
+    
 
     return (
       <div className={`${categoryMenu.container} ${categoryMenu.mobile}`}>
@@ -96,14 +107,21 @@ class CategoryMenu extends Component {
       intl,
       showAllDepartments,
       showSubcategories,
+      menuDisposition,
     } = this.props
     
     const {
       params: {department = ""}
     } = this.props.runtime.route
+    
+    const desktopClasses = classNames(`${categoryMenu.container} w-100 bg-base dn flex-m ph3 ph5-m ph8-l ph9-xl`, {
+      'justify-start': menuDisposition === categoryMenuDisposition.DISPLAY_LEFT.value,
+      'justify-end': menuDisposition === categoryMenuDisposition.DISPLAY_RIGHT.value,
+      'justify-center': menuDisposition === categoryMenuDisposition.DISPLAY_CENTER.value
+    })
 
     return (
-      <nav className={`${categoryMenu.container} relative dn-s flex-ns justify-center items-center bg-base`}>
+      <nav className={desktopClasses}>
         <ul className="pa0 list ma0 flex flex-wrap flex-row t-action overflow-hidden h3">
           {showAllDepartments &&
           <CategoryItem noRedirect subcategoryLevels={DEFAULT_SUBCATEGORIES_LEVELS + showSubcategories} category={{
@@ -150,6 +168,14 @@ CategoryMenuWithIntl.schema = CategoryMenu.schema = {
       type: 'boolean',
       title: 'editor.category-menu.show-departments-category.title',
       default: CategoryMenu.defaultProps.showAllDepartments,
+    },
+    menuDisposition: {
+      title: 'editor.category-menu.disposition-type.title',
+      type: 'string',
+      enum: getMenuDispositionValues(),
+      enumNames: getMenuDispositionNames(),
+      default: categoryMenuDisposition.DISPLAY_LEFT.value,
+      isLayout: true,
     },
     showSubcategories: {
       type: 'boolean',

--- a/react/index.js
+++ b/react/index.js
@@ -17,7 +17,7 @@ import categoryMenu from './categoryMenu.css'
 import categoryMenuDisposition, {
   getMenuDispositionNames,
   getMenuDispositionValues,
-} from './utils/categoryMenuDisposition' 
+} from './utils/categoryMenuDisposition'
 
 const DEFAULT_SUBCATEGORIES_LEVELS = 1
 
@@ -82,7 +82,7 @@ class CategoryMenu extends Component {
       intl,
       showSubcategories,
     } = this.props
-    
+
     const { sideBarVisible } = this.state
 
     return (
@@ -108,15 +108,15 @@ class CategoryMenu extends Component {
       showSubcategories,
       menuDisposition,
     } = this.props
-    
+
     const {
-      params: {department = ""}
+      params: { department = '' },
     } = this.props.runtime.route
-    
+
     const desktopClasses = classNames(`${categoryMenu.container} w-100 bg-base dn flex-m`, {
       'justify-start mw9': menuDisposition === categoryMenuDisposition.DISPLAY_LEFT.value,
       'justify-end mw9': menuDisposition === categoryMenuDisposition.DISPLAY_RIGHT.value,
-      'justify-center': menuDisposition === categoryMenuDisposition.DISPLAY_CENTER.value
+      'justify-center': menuDisposition === categoryMenuDisposition.DISPLAY_CENTER.value,
     })
 
     return (
@@ -124,22 +124,22 @@ class CategoryMenu extends Component {
         <nav className={desktopClasses}>
           <ul className="pa0 list ma0 flex flex-wrap flex-row t-action overflow-hidden h3">
             {showAllDepartments &&
-            <CategoryItem 
-              noRedirect 
-              menuDisposition={menuDisposition} 
+            <CategoryItem
+              noRedirect
+              menuDisposition={menuDisposition}
               subcategoryLevels={DEFAULT_SUBCATEGORIES_LEVELS + showSubcategories}
               category={{
                 children: categories,
                 name: intl.formatMessage({ id: 'category-menu.departments.title' }),
-              }} 
+              }}
             />
             }
-            {this.departments.map((category, index) => (
+            {this.departments.map((category) => (
               <Fragment key={category.id}>
-                <CategoryItem 
+                <CategoryItem
                   menuDisposition={menuDisposition}
-                  category={category} 
-                  subcategoryLevels={DEFAULT_SUBCATEGORIES_LEVELS + showSubcategories} 
+                  category={category}
+                  subcategoryLevels={DEFAULT_SUBCATEGORIES_LEVELS + showSubcategories}
                   isCategorySelected={department === category.slug}
                 />
               </Fragment>

--- a/react/index.js
+++ b/react/index.js
@@ -3,12 +3,10 @@ import React, { Component, Fragment } from 'react'
 import { graphql } from 'react-apollo'
 import { injectIntl, intlShape } from 'react-intl'
 import { IconMenu } from 'vtex.dreamstore-icons'
-<<<<<<< HEAD
 import { withRuntimeContext } from 'vtex.render-runtime'
 import { compose } from 'ramda'
-=======
 import classNames from 'classnames'
->>>>>>> Add menu disposition types on storefront
+import { Container } from 'vtex.store-components'
 
 import CategoryItem from './components/CategoryItem'
 import SideBar from './components/SideBar'
@@ -85,6 +83,7 @@ class CategoryMenu extends Component {
       showSubcategories,
     } = this.props
     
+    const { sideBarVisible } = this.state
 
     return (
       <div className={`${categoryMenu.container} ${categoryMenu.mobile}`}>
@@ -114,32 +113,40 @@ class CategoryMenu extends Component {
       params: {department = ""}
     } = this.props.runtime.route
     
-    const desktopClasses = classNames(`${categoryMenu.container} w-100 bg-base dn flex-m ph3 ph5-m ph8-l ph9-xl`, {
-      'justify-start': menuDisposition === categoryMenuDisposition.DISPLAY_LEFT.value,
-      'justify-end': menuDisposition === categoryMenuDisposition.DISPLAY_RIGHT.value,
+    const desktopClasses = classNames(`${categoryMenu.container} w-100 bg-base dn flex-m`, {
+      'justify-start mw9': menuDisposition === categoryMenuDisposition.DISPLAY_LEFT.value,
+      'justify-end mw9': menuDisposition === categoryMenuDisposition.DISPLAY_RIGHT.value,
       'justify-center': menuDisposition === categoryMenuDisposition.DISPLAY_CENTER.value
     })
 
     return (
-      <nav className={desktopClasses}>
-        <ul className="pa0 list ma0 flex flex-wrap flex-row t-action overflow-hidden h3">
-          {showAllDepartments &&
-          <CategoryItem noRedirect subcategoryLevels={DEFAULT_SUBCATEGORIES_LEVELS + showSubcategories} category={{
-            children: categories,
-            name: intl.formatMessage({ id: 'category-menu.departments.title' }),
-          }} />
-          }
-          {this.departments.map(category => (
-            <Fragment key={category.id}>
-              <CategoryItem 
-                category={category} 
-                subcategoryLevels={DEFAULT_SUBCATEGORIES_LEVELS + showSubcategories} 
-                isCategorySelected={department === category.slug}
-              />
-            </Fragment>
-          ))}
-        </ul>
-      </nav>
+      <Container className="justify-center flex">
+        <nav className={desktopClasses}>
+          <ul className="pa0 list ma0 flex flex-wrap flex-row t-action overflow-hidden h3">
+            {showAllDepartments &&
+            <CategoryItem 
+              noRedirect 
+              menuDisposition={menuDisposition} 
+              subcategoryLevels={DEFAULT_SUBCATEGORIES_LEVELS + showSubcategories}
+              category={{
+                children: categories,
+                name: intl.formatMessage({ id: 'category-menu.departments.title' }),
+              }} 
+            />
+            }
+            {this.departments.map((category, index) => (
+              <Fragment key={category.id}>
+                <CategoryItem 
+                  menuDisposition={menuDisposition}
+                  category={category} 
+                  subcategoryLevels={DEFAULT_SUBCATEGORIES_LEVELS + showSubcategories} 
+                  isCategorySelected={department === category.slug}
+                />
+              </Fragment>
+            ))}
+          </ul>
+        </nav>
+      </Container>
     )
   }
 

--- a/react/package.json
+++ b/react/package.json
@@ -8,6 +8,7 @@
     "apollo-client": "^2.4.7",
     "classnames": "^2.2.6",
     "graphql": "^14.0.2",
+    "ramda": "^0.26.1",
     "jsdom": "^11.8.0",
     "ramda": "^0.26.1",
     "react-apollo": "^2.3.2",

--- a/react/utils/categoryMenuDisposition.js
+++ b/react/utils/categoryMenuDisposition.js
@@ -1,0 +1,26 @@
+import { values, map } from 'ramda'
+
+const categoryMenuDisposition = {
+  DISPLAY_CENTER: {
+    name: 'editor.category-menu.disposition-type.center',
+    value: 'center',
+  },
+  DISPLAY_LEFT: {
+    name: 'editor.category-menu.disposition-type.left',
+    value: 'left',
+  },
+  DISPLAY_RIGHT: {
+    name: 'editor.category-menu.disposition-type.right',
+    value: 'right',
+  },
+}
+
+export function getMenuDispositionNames() {
+  return map(opt => opt.name, values(categoryMenuDisposition))
+}
+
+export function getMenuDispositionValues() {
+  return map(opt => opt.value, values(categoryMenuDisposition))
+}
+
+export default categoryMenuDisposition

--- a/react/utils/categoryMenuDisposition.js
+++ b/react/utils/categoryMenuDisposition.js
@@ -1,4 +1,4 @@
-import { values, map } from 'ramda'
+import { values, pluck } from 'ramda'
 
 const categoryMenuDisposition = {
   DISPLAY_CENTER: {
@@ -16,11 +16,11 @@ const categoryMenuDisposition = {
 }
 
 export function getMenuDispositionNames() {
-  return map(opt => opt.name, values(categoryMenuDisposition))
+  return pluck('name', values(categoryMenuDisposition))
 }
 
 export function getMenuDispositionValues() {
-  return map(opt => opt.value, values(categoryMenuDisposition))
+  return pluck('value', values(categoryMenuDisposition))
 }
 
 export default categoryMenuDisposition


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add types of disposition for the category menu (right, left, center) to be choose on storefront.

#### What problem is this solving?
Better customizability on category menu.

#### How should this be manually tested?
[Access](https://kitfix--storecomponents.myvtex.com/)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

