### PR TITLE
Fix the return result of 'get departments()' function allowing the customization of categories via props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.8.2] - 2019-02-04
 ### Fixed
 - Fix the return result of 'get departments()' function allowing the customization of categories by props.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix the return result of 'get departments()' function allowing the customization of categories by props.
 
 ## [2.8.1] - 2019-02-01
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "category-menu",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "title": "Category Menu",
   "description": "Displays the categories for the store in a menu",
   "defaultLocale": "pt-BR",

--- a/react/index.js
+++ b/react/index.js
@@ -70,7 +70,6 @@ class CategoryMenu extends Component {
 
   renderSideBar() {
     const {
-      data: { categories = [] },
       intl,
       showSubcategories,
     } = this.props

--- a/react/index.js
+++ b/react/index.js
@@ -64,7 +64,8 @@ class CategoryMenu extends Component {
     const { data: { categories = [] }, departments } = this.props
     const departmentsIds = departments.map(dept => dept.id)
     const departmentsSelected = categories.filter(category => departmentsIds.includes(category.id))
-    return (this.departmentsSelected && departmentsSelected.length) || categories
+
+    return (departmentsSelected.length && departmentsSelected) || categories
   }
 
   renderSideBar() {
@@ -80,7 +81,7 @@ class CategoryMenu extends Component {
         <SideBar
           visible={sideBarVisible}
           title={intl.formatMessage({ id: 'category-menu.departments.title' })}
-          departments={categories}
+          departments={this.departments}
           onClose={this.handleSidebarToggle}
           showSubcategories={showSubcategories} />
         <div className="flex pa4 pointer" onClick={this.handleSidebarToggle}>


### PR DESCRIPTION
#### What is the purpose of this pull request?
As described on the title.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The user could not choose which categories would be displayed in the Category Menu due to this error in the return result. Now it is working. 

#### How should this be manually tested?
This should be tested via Store Front inserting custom props or passing it via blocks. This is an [example](https://customcategorymenu--storecomponents.myvtex.com/) using some custom categories via _defaultProps_ once Store Front is not working yet.

#### Screenshots or example usage
Desktop
![captura de tela de 2019-02-04 16-49-04](https://user-images.githubusercontent.com/9946330/52233077-eeec8d00-289c-11e9-9dc8-633235969e7f.png)

Desktop without 'Departments'
![captura de tela de 2019-02-04 16-53-29](https://user-images.githubusercontent.com/9946330/52233311-7f2ad200-289d-11e9-9cfa-981312d37c5a.png)

Mobile
![captura de tela de 2019-02-04 16-48-29](https://user-images.githubusercontent.com/9946330/52233087-f3b14100-289c-11e9-9767-44d459ab0b20.png)



#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

