### PR TITLE
Remove overflow-hidden from container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.11.2] - 2019-02-19
+
 ### Fixed
 - Removed `overflow-hidden` from container in order to display submenus.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Removed `overflow-hidden` from container in order to display submenus.
+
 ## [2.11.1] - 2019-02-18
 
 ## [2.11.0] - 2019-02-15

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "category-menu",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "title": "Category Menu",
   "description": "Displays the categories for the store in a menu",
   "defaultLocale": "pt-BR",

--- a/react/index.js
+++ b/react/index.js
@@ -134,7 +134,7 @@ class CategoryMenu extends Component {
     )
 
     return (
-      <Container className="justify-center flex overflow-hidden">
+      <Container className="justify-center flex">
         <nav className={desktopClasses}>
           <ul className="pa0 list ma0 flex flex-wrap flex-row t-action overflow-hidden h3">
             {showAllDepartments && (


### PR DESCRIPTION
This overflow-hidden was concealing the category submenus. This PR fixes this issue.