### PR TITLE
Fix/sidemenu text token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.11.3] - 2019-02-21
+
 ### Changed
 - Sidemenu sections text token from `t-heading-4` to `t-body`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Sidemenu sections text token from `t-heading-4` to `t-body`
+
 ## [2.11.2] - 2019-02-19
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "category-menu",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "title": "Category Menu",
   "description": "Displays the categories for the store in a menu",
   "defaultLocale": "pt-BR",

--- a/react/components/SideBarItem.js
+++ b/react/components/SideBarItem.js
@@ -95,7 +95,7 @@ class SideBarItem extends Component {
       'flex justify-between items-center pa5 pointer list ma0'      
     )
     const sideBarItemTitleClasses = classNames('', {
-      't-heading-4 lh-solid': treeLevel === 1,
+      't-body lh-solid': treeLevel === 1,
     })
 
     const sideBarSpanClasses = classNames(


### PR DESCRIPTION
#### What is the purpose of this pull request?
Previously the font token for the headings of the sidemenu were `t-heading-4`. This could be a poor fit if the heading was of a large font size. This sets them to `t-body`, which is more sane, while the icons and colors confer them enough hierarchy

Before:
<img width="385" alt="screen shot 2019-02-21 at 18 38 27" src="https://user-images.githubusercontent.com/5691711/53203529-26cb3280-3608-11e9-80e3-6b6b802750f3.png">

After:
<img width="433" alt="screen shot 2019-02-21 at 18 38 13" src="https://user-images.githubusercontent.com/5691711/53203534-2c287d00-3608-11e9-9a5b-dd814161fa1a.png">


#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

