### PR TITLE
Remove uppercase from links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.11.6] - 2019-03-21
+
 ### Fixed
 
 - Remove uppercase from links

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove uppercase from links
+
 ## [2.11.5] - 2019-03-14
 ### Changed
 - Change language files to most generic.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "category-menu",
-  "version": "2.11.5",
+  "version": "2.11.6",
   "title": "Category Menu",
   "description": "Displays the categories for the store in a menu",
   "defaultLocale": "pt-BR",

--- a/react/__tests__/CategoryItem.test.js
+++ b/react/__tests__/CategoryItem.test.js
@@ -25,9 +25,9 @@ describe('CategoryItem component', () => {
   })
 
   it('should have the correct href', () => {
-    const element = wrapper.getByText(/CATEGORY/)
+    const element = wrapper.getByText(/CATEGORY/i)
 
-    expect(element.href).toMatch(/\/category\/s$/)
+    expect(element.href).toMatch(/\/category\/s$/i)
   })
 
   it('should match snapshot', () => {

--- a/react/__tests__/__snapshots__/CategoryItem.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryItem.test.js.snap
@@ -6,10 +6,10 @@ exports[`CategoryItem component should match snapshot 1`] = `
     class="itemContainer flex items-center db list"
   >
     <a
-      class="w-100 pv5 no-underline t-small outline-0 db tc ttu link truncate bb bw1 c-muted-1 b--transparent"
+      class="w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
       href="/category/s"
     >
-      CATEGORY
+      Category
     </a>
   </li>
 </DocumentFragment>

--- a/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
@@ -12,9 +12,9 @@ exports[`CategoryMenu component should match snapshot 1`] = `
         class="itemContainer flex items-center db list"
       >
         <span
-          class="w-100 pv5 no-underline t-small outline-0 db tc ttu link truncate bb bw1 c-muted-1 b--transparent mh6"
+          class="w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent mh6"
         >
-          DEPARTMENTS
+          Departments
         </span>
         <div
           class="itemContainer absolute w-100 left-0 bg-base pb2 bw1 bb b--muted-3"
@@ -36,7 +36,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                     class="firstLevelLink db pv4 link no-underline outline-0 tl t-small truncate c-on-base underline-hover ph4"
                     href="/category-1/s"
                   >
-                    CATEGORY 1
+                    Category 1
                   </a>
                 </li>
               </ul>
@@ -54,7 +54,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                     class="firstLevelLink db pv4 link no-underline outline-0 tl t-small truncate c-on-base underline-hover ph4"
                     href="/category-2/s"
                   >
-                    CATEGORY 2
+                    Category 2
                   </a>
                 </li>
               </ul>
@@ -72,7 +72,7 @@ exports[`CategoryMenu component should match snapshot 1`] = `
                     class="firstLevelLink db pv4 link no-underline outline-0 tl t-small truncate c-on-base underline-hover ph4"
                     href="/category-3/s"
                   >
-                    CATEGORY 3
+                    Category 3
                   </a>
                 </li>
               </ul>
@@ -84,30 +84,30 @@ exports[`CategoryMenu component should match snapshot 1`] = `
         class="itemContainer flex items-center db list"
       >
         <a
-          class="w-100 pv5 no-underline t-small outline-0 db tc ttu link truncate bb bw1 c-muted-1 b--transparent mh6"
+          class="w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent mh6"
           href="/category-1/s"
         >
-          CATEGORY 1
+          Category 1
         </a>
       </li>
       <li
         class="itemContainer flex items-center db list"
       >
         <a
-          class="w-100 pv5 no-underline t-small outline-0 db tc ttu link truncate bb bw1 c-muted-1 b--transparent mh6"
+          class="w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent mh6"
           href="/category-2/s"
         >
-          CATEGORY 2
+          Category 2
         </a>
       </li>
       <li
         class="itemContainer flex items-center db list"
       >
         <a
-          class="w-100 pv5 no-underline t-small outline-0 db tc ttu link truncate bb bw1 c-muted-1 b--transparent mh6"
+          class="w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent mh6"
           href="/category-3/s"
         >
-          CATEGORY 3
+          Category 3
         </a>
       </li>
     </ul>

--- a/react/components/CategoryItem.js
+++ b/react/components/CategoryItem.js
@@ -44,7 +44,7 @@ export default class CategoryItem extends Component {
     const { isOnHover } = this.state
 
     const categoryClasses = classNames(
-      'w-100 pv5 no-underline t-small outline-0 db tc ttu link truncate bb bw1 c-muted-1',
+      'w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1',
       {
         'b--transparent': !isOnHover && !isCategorySelected,
         'b--action-primary pointer': isOnHover || isCategorySelected,
@@ -55,7 +55,7 @@ export default class CategoryItem extends Component {
     )
 
     return noRedirect ? (
-      <span className={categoryClasses}>{name.toUpperCase()}</span>
+      <span className={categoryClasses}>{name}</span>
     ) : (
       <Link
         onClick={this.handleCloseMenu}
@@ -63,7 +63,7 @@ export default class CategoryItem extends Component {
         params={{ department: slug }}
         className={categoryClasses}
       >
-        {name.toUpperCase()}
+        {name}
       </Link>
     )
   }

--- a/react/components/ItemContainer.js
+++ b/react/components/ItemContainer.js
@@ -57,7 +57,7 @@ export default class ItemContainer extends Component {
           className={firstLevelLinkClasses}
           params={params}
         >
-          {item.name.toUpperCase()}
+          {item.name}
         </Link>
       </li>
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove `toUppercase()` from links so it's easier to customize it with CSS.

#### What problem is this solving?
Transforming the text to uppercase with JS made it impossible to change the casing with CSS.

#### How should this be manually tested?
See: https://breno--storecomponents.myvtex.com/

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/284515/54776043-0afa8280-4bee-11e9-8065-572a04f77c9a.png)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

