### PR TITLE
Add CSS Blocks to Category Menu for Overwrite the Menu Item Styles 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added 
+- Added few CSS blocks `sidebarItemContainer`, `menuItemLabel`, `itemsListContainer` and `listItemContainer` to `categoryMenu.css` so it can be overwritten by `vtex.store-theme`
 
 ## [2.11.6] - 2019-03-21
 

--- a/react/__tests__/__snapshots__/CategoryItem.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryItem.test.js.snap
@@ -3,10 +3,10 @@
 exports[`CategoryItem component should match snapshot 1`] = `
 <DocumentFragment>
   <li
-    class="itemContainer flex items-center db list"
+    class="listItemContainer itemContainer flex items-center db list"
   >
     <a
-      class="w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
+      class="menuItemLabel w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent"
       href="/category/s"
     >
       Category

--- a/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
+++ b/react/__tests__/__snapshots__/CategoryMenu.test.js.snap
@@ -6,13 +6,13 @@ exports[`CategoryMenu component should match snapshot 1`] = `
     class="container w-100 bg-base dn flex-m justify-center"
   >
     <ul
-      class="pa0 list ma0 flex flex-wrap flex-row t-action overflow-hidden h3"
+      class="itemsListContainer pa0 list ma0 flex flex-wrap flex-row t-action overflow-hidden h3"
     >
       <li
-        class="itemContainer flex items-center db list"
+        class="listItemContainer itemContainer flex items-center db list"
       >
         <span
-          class="w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent mh6"
+          class="menuItemLabel w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent mh6"
         >
           Departments
         </span>
@@ -81,30 +81,30 @@ exports[`CategoryMenu component should match snapshot 1`] = `
         </div>
       </li>
       <li
-        class="itemContainer flex items-center db list"
+        class="listItemContainer itemContainer flex items-center db list"
       >
         <a
-          class="w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent mh6"
+          class="menuItemLabel w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent mh6"
           href="/category-1/s"
         >
           Category 1
         </a>
       </li>
       <li
-        class="itemContainer flex items-center db list"
+        class="listItemContainer itemContainer flex items-center db list"
       >
         <a
-          class="w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent mh6"
+          class="menuItemLabel w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent mh6"
           href="/category-2/s"
         >
           Category 2
         </a>
       </li>
       <li
-        class="itemContainer flex items-center db list"
+        class="listItemContainer itemContainer flex items-center db list"
       >
         <a
-          class="w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent mh6"
+          class="menuItemLabel w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1 b--transparent mh6"
           href="/category-3/s"
         >
           Category 3

--- a/react/categoryMenu.css
+++ b/react/categoryMenu.css
@@ -35,3 +35,11 @@
 .menuContainer {}
 
 .sidebarItemContainer {}
+
+.menuItemLabel {}
+
+.itemsListContainer {}
+
+.listItemContainer {
+  max-height: 21.875rem;
+}

--- a/react/components/CategoryItem.js
+++ b/react/components/CategoryItem.js
@@ -44,7 +44,7 @@ export default class CategoryItem extends Component {
     const { isOnHover } = this.state
 
     const categoryClasses = classNames(
-      'w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1',
+      `${categoryMenu.menuItemLabel} w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1`,
       {
         'b--transparent': !isOnHover && !isCategorySelected,
         'b--action-primary pointer': isOnHover || isCategorySelected,
@@ -95,7 +95,7 @@ export default class CategoryItem extends Component {
   render() {
     return (
       <li
-        className={`${categoryMenu.itemContainer} flex items-center db list`}
+        className={`${categoryMenu.listItemContainer} flex items-center db list`}
         ref={e => {
           this.item = e
         }}

--- a/react/components/CategoryItem.js
+++ b/react/components/CategoryItem.js
@@ -43,8 +43,8 @@ export default class CategoryItem extends Component {
     } = this.props
     const { isOnHover } = this.state
 
-    const categoryClasses = classNames(
-      `${categoryMenu.menuItemLabel} w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1`,
+    const categoryClasses = classNames(categoryMenu.menuItemLabel,
+      "w-100 pv5 no-underline t-small outline-0 db tc link truncate bb bw1 c-muted-1",
       {
         'b--transparent': !isOnHover && !isCategorySelected,
         'b--action-primary pointer': isOnHover || isCategorySelected,
@@ -93,9 +93,15 @@ export default class CategoryItem extends Component {
   }
 
   render() {
+    
+    const listItemContainerClasses = classNames(
+      categoryMenu.listItemContainer, 
+      categoryMenu.itemContainer, 
+      "flex items-center db list")
+
     return (
       <li
-        className={`${categoryMenu.listItemContainer} flex items-center db list`}
+        className={ listItemContainerClasses }
         ref={e => {
           this.item = e
         }}

--- a/react/index.js
+++ b/react/index.js
@@ -133,10 +133,12 @@ class CategoryMenu extends Component {
       }
     )
 
+    const itemListClass = `${categoryMenu.itemsListContainer} pa0 list ma0 flex flex-wrap flex-row t-action overflow-hidden h3`
+
     return (
       <nav className={desktopClasses}>
         <Container className="justify-center flex">
-          <ul className="pa0 list ma0 flex flex-wrap flex-row t-action overflow-hidden h3">
+          <ul className={itemListClass}>
             {showAllDepartments && (
               <CategoryItem
                 noRedirect

--- a/react/index.js
+++ b/react/index.js
@@ -133,7 +133,7 @@ class CategoryMenu extends Component {
       }
     )
 
-    const itemListClass = `${categoryMenu.itemsListContainer} pa0 list ma0 flex flex-wrap flex-row t-action overflow-hidden h3`
+    const itemListClass = classNames(categoryMenu.itemsListContainer, "pa0 list ma0 flex flex-wrap flex-row t-action overflow-hidden h3")
 
     return (
       <nav className={desktopClasses}>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add few CSS blocks to category menu so we will be able to overwrite them in `vtex.store-theme` application. 
Purpose of overwrite is to reduce the height of the menu bar. 

#### What problem is this solving?
Add more flexibility on CSS overwrites 

#### How should this be manually tested?
CSS classes are visible in web page when we inspect them. 

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

