### PR TITLE
fix: Change see all trigger to works also in category and subcategory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Fixed
 - See all link work inside `category` and `subcategory`in mobile
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- See all link work inside `category` and `subcategory`in mobile
 
 ## [2.14.1] - 2020-09-02
 ### Fixed

--- a/react/components/SideBarItem.js
+++ b/react/components/SideBarItem.js
@@ -43,18 +43,6 @@ const SideBarItem = ({
     onClose()
   }
 
-  const handleDepartmentClick = () => {
-    const [department] = linkValues
-    const params = { department }
-    const page = 'store.search#department'
-    runtime.navigate({
-      page,
-      params,
-      fallbackToWindowLocation: false,
-    })
-    onClose()
-  }
-
   const handleItemClick = () => {
     if (subCategoriesVisible) {
       setOpen(prevOpen => !prevOpen)
@@ -91,10 +79,10 @@ const SideBarItem = ({
         )}
       </li>
       {subCategoriesVisible && open && (
-        <Fragment>
+        <>
           <li
             className="pa5 pointer t-body c-muted-2 ma0 list"
-            onClick={handleDepartmentClick}
+            onClick={navigateToPage}
           >
             <FormattedMessage id="store/category-menu.all-category.title">
               {txt => <span className="pl4">{txt}</span>}
@@ -112,7 +100,7 @@ const SideBarItem = ({
               />
             </li>
           ))}
-        </Fragment>
+        </>
       )}
     </ul>
   )


### PR DESCRIPTION
#### What problem is this solving?

Actually, the see all button only works in department tree level, if you are inside category or subcategory level and click in "see all", it will redirect to department level and that's it. This PR is solving it, to "see all" redirect you to the level that you are in

#### How to test it?

Switch the view to **mobile version**, go to menu, and then, click on see all inside department and inside category and subcategory

[Older](https://master--muji.myvtex.com/)
[Fixed](https://iespinoza--muji.myvtex.com/)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/13649073/96469921-24b5de80-1204-11eb-94d0-366ab93c01ad.png)


#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/VhE7ABvkD8CHe/giphy.gif)
